### PR TITLE
Refactor the catalogue info admin and make images read-only

### DIFF
--- a/exhibitors/admin.py
+++ b/exhibitors/admin.py
@@ -4,6 +4,7 @@ from .models import Exhibitor, WorkField, JobType, \
     Continent, Value, CatalogInfo, Location, BanquetteAttendant
 
 
+@admin.register(CatalogInfo)
 class CatalogInfoAdmin(admin.ModelAdmin):
     fieldsets = (
         (None, {
@@ -31,6 +32,5 @@ admin.site.register(WorkField)
 admin.site.register(JobType)
 admin.site.register(Continent)
 admin.site.register(Value)
-admin.site.register(CatalogInfo, CatalogInfoAdmin)
 admin.site.register(Location)
 admin.site.register(BanquetteAttendant)

--- a/exhibitors/admin.py
+++ b/exhibitors/admin.py
@@ -1,7 +1,29 @@
 from django.contrib import admin
 
 from .models import Exhibitor, WorkField, JobType, \
-        Continent, Value, CatalogInfo, Location, BanquetteAttendant
+    Continent, Value, CatalogInfo, Location, BanquetteAttendant
+
+
+class CatalogInfoAdmin(admin.ModelAdmin):
+    fieldsets = (
+        (None, {
+            'fields': ('exhibitor', 'display_name', 'slug', 'short_description',
+                       'description', 'employees_sweden', 'employees_world',
+                       'countries', 'website_url', 'facebook_url',
+                       'twitter_url', 'linkedin_url',)
+        }),
+        ('Images', {
+            'classes': ('collapse',),
+            'fields': ('logo_original', 'logo_small', 'logo', 'ad_original', 'ad',)
+        }),
+        ('Details', {
+            'classes': ('collapse',),
+            'fields': ('programs', 'main_work_field', 'work_fields',
+                       'job_types', 'continents', 'values', 'tags',)
+        })
+    )
+    readonly_fields = ('logo_small', 'logo', 'ad',)
+
 
 # Register your models here.
 admin.site.register(Exhibitor)
@@ -9,6 +31,6 @@ admin.site.register(WorkField)
 admin.site.register(JobType)
 admin.site.register(Continent)
 admin.site.register(Value)
-admin.site.register(CatalogInfo)
+admin.site.register(CatalogInfo, CatalogInfoAdmin)
 admin.site.register(Location)
 admin.site.register(BanquetteAttendant)


### PR DESCRIPTION
**UPDATE**: Changes are now implemented for Events as well.

This PR eliminates the risk that someone uploads any other images other than logo_original and ad_original. The other images fields are generated from the two aformentioned ones and should therefore not be modified. The generated images are now read-only but are still available in the admin in case someone wants to see a preview.

The admin site for catalogue info has also been refactored using collapsable classes, improving readability.

Images:

<img width="1407" alt="screen shot 2016-10-31 at 19 29 52" src="https://cloud.githubusercontent.com/assets/11392811/19866467/852e94d0-9fa0-11e6-9194-c42fe8fca54b.png">

----------------------------
----------------------------

<img width="1402" alt="screen shot 2016-10-31 at 19 29 58" src="https://cloud.githubusercontent.com/assets/11392811/19866473/8af5017e-9fa0-11e6-89ab-59ade697cc6c.png">

----------------------------
----------------------------

<img width="1395" alt="screen shot 2016-10-31 at 19 30 13" src="https://cloud.githubusercontent.com/assets/11392811/19866476/8e4ababc-9fa0-11e6-994b-90197f788e84.png">
