### PR TITLE
Etag nginx

### DIFF
--- a/ais/common/settings.py
+++ b/ais/common/settings.py
@@ -57,6 +57,8 @@ MIDDLEWARE_CLASSES = (
     'recruitment.middleware.LoginRequiredMiddleware'
 )
 
+USE_ETAGS = True
+
 AUTHENTICATION_BACKENDS = (
     'django.contrib.auth.backends.ModelBackend',
 )

--- a/ais_nginx.conf
+++ b/ais_nginx.conf
@@ -28,7 +28,7 @@ server {
     client_max_body_size 75M;   # adjust to taste
 
     gzip off;
-	etag on;
+    etag on;
 
     location /.well-known {
         alias /home/deployment/https/.well-known;

--- a/ais_nginx.conf
+++ b/ais_nginx.conf
@@ -15,6 +15,9 @@ server {
     return 301 https://$server_name$request_uri;
 }
 
+uwsgi_cache_path /etc/nginx/cache levels=1:2 keys_zone=api_cache:10m inactive=60m;
+uwsgi_cache_key "$scheme$request_method$host$request_uri";
+
 server {
 
     listen 443 ssl default_server;
@@ -25,7 +28,6 @@ server {
     client_max_body_size 75M;   # adjust to taste
 
     gzip off;
-    etag on;
 
     location /.well-known {
         alias /home/deployment/https/.well-known;
@@ -53,6 +55,8 @@ server {
 
     location /api {
         uwsgi_pass  django;
+        uwsgi_cache api_cache;
+        uwsgi_cache_valid 200 5m;
         include    /home/deployment/ais/uwsgi_params; # the uwsgi_params file you installed
         add_header 'Access-Control-Allow-Origin' '*';
         add_header 'Access-Control-Allow-Methods' 'GET, POST, OPTIONS';

--- a/ais_nginx.conf
+++ b/ais_nginx.conf
@@ -28,6 +28,7 @@ server {
     client_max_body_size 75M;   # adjust to taste
 
     gzip off;
+	etag on;
 
     location /.well-known {
         alias /home/deployment/https/.well-known;

--- a/ais_uwsgi.ini
+++ b/ais_uwsgi.ini
@@ -36,7 +36,3 @@ pidfile=/home/deployment/ais-master.pid
 
 # clear environment on exit
 vacuum = true
-
-# cache all api requests for 5 minutes
-cache2 = name=api,items=10,bitmap=1,blocks=100
-route = ^/api/(.+) cache:key=${REQUEST_URI},name=api,expires=300

--- a/api/views.py
+++ b/api/views.py
@@ -17,7 +17,14 @@ def root(request):
 def exhibitors(request):
     exhibitors = Exhibitor.objects.filter(
             fair__name=CURRENT_FAIR
-            ).select_related('cataloginfo')
+            ).select_related('cataloginfo').prefetch_related(
+                'cataloginfo__programs',
+                'cataloginfo__main_work_field',
+                'cataloginfo__work_fields',
+                'cataloginfo__job_types',
+                'cataloginfo__continents',
+                'cataloginfo__values',
+            )
     data = [serializers.exhibitor(request, exhibitor.cataloginfo)
             for exhibitor in exhibitors]
     return JsonResponse(data, safe=False)


### PR DESCRIPTION
- ETag middleware in django (for all requests, any reason why not?)
- Prefetch related models in api/exhibitors
- Cache api requests in nginx, this will require an nginx reload after deploy