### PR TITLE
Add image previews for events and catalogue info

### DIFF
--- a/events/admin.py
+++ b/events/admin.py
@@ -3,20 +3,20 @@ from django.contrib import messages
 from django.contrib import admin
 from .models import Event, EventAttendence, EventQuestion, EventAnswer
 from django.http import HttpResponse
-
+from lib.util import image_preview
 
 # Exports all the EventAnswers that belong to a single Event
 # (Could be expanded to include User information)
 def export_as_csv(modeladmin, request, queryset):
     if len(queryset) != 1:
-        modeladmin.message_user(request, 
+        modeladmin.message_user(request,
             "Please select a single event to export", level=messages.ERROR)
         return
 
     response = HttpResponse(content_type="text/csv")
     response['Content-Disposition'] = 'attachment; filename=event.csv'
 
-    # We have already checked that it is a single event    
+    # We have already checked that it is a single event
     event_id = queryset.first().id
     csv_headers = ['First name (user)', 'Last name (user)', 'Email (user)']
     csv_headers.append('Status')
@@ -37,7 +37,7 @@ def export_as_csv(modeladmin, request, queryset):
                 attendence.user.last_name,
                 attendence.user.email,
             ]
- 
+
         status = [attendence.status]
 
         answers = []
@@ -89,10 +89,7 @@ class EventAdmin(admin.ModelAdmin):
     filter_horizontal = ("allowed_groups",)
     actions = [export_as_csv]
 
-    def event_image_preview(self, instance):
-        return '<img src="%s" />' % instance.image.url
-    event_image_preview.allow_tags = True
-    event_image_preview.short_description = "Preview of image"
+    event_image_preview = image_preview('image')
 
 
 class AnswerInline(admin.StackedInline):
@@ -101,7 +98,7 @@ class AnswerInline(admin.StackedInline):
 
 class EventAttendenceAdmin(admin.ModelAdmin):
     inlines = [AnswerInline]
-    search_fields = ['user__first_name', 'user__last_name', 'user__email', 
+    search_fields = ['user__first_name', 'user__last_name', 'user__email',
         'event__name']
     list_filter = ('event',)
 

--- a/events/admin.py
+++ b/events/admin.py
@@ -77,14 +77,14 @@ class EventAdmin(admin.ModelAdmin):
         }),
         ('Images', {
             'classes': ('collapse',),
-            'fields': ('image_original', 'image', 'event_image_preview',)
+            'fields': ('image_original', 'event_image_preview',)
         }),
         (None, {
             'fields': ('tags',)
         })
     )
     list_filter = ('published', 'registration_required',)
-    readonly_fields = ('image', 'event_image_preview', 'extra_field',)
+    readonly_fields = ('event_image_preview', 'extra_field',)
     inlines = [QuestionInline]
     filter_horizontal = ("allowed_groups",)
     actions = [export_as_csv]

--- a/events/admin.py
+++ b/events/admin.py
@@ -77,17 +77,22 @@ class EventAdmin(admin.ModelAdmin):
         }),
         ('Images', {
             'classes': ('collapse',),
-            'fields': ('image_original', 'image',)
+            'fields': ('image_original', 'image', 'event_image_preview',)
         }),
         (None, {
             'fields': ('tags',)
         })
     )
     list_filter = ('published', 'registration_required',)
-    readonly_fields = ('image', 'extra_field')
+    readonly_fields = ('image', 'event_image_preview', 'extra_field',)
     inlines = [QuestionInline]
     filter_horizontal = ("allowed_groups",)
     actions = [export_as_csv]
+
+    def event_image_preview(self, instance):
+        return '<img src="%s" />' % instance.image.url
+    event_image_preview.allow_tags = True
+    event_image_preview.short_description = "Preview of image"
 
 
 class AnswerInline(admin.StackedInline):

--- a/exhibitors/admin.py
+++ b/exhibitors/admin.py
@@ -17,7 +17,8 @@ class CatalogInfoAdmin(admin.ModelAdmin):
         }),
         ('Images', {
             'classes': ('collapse',),
-            'fields': ('logo_original', 'logo_small', 'logo', 'ad_original', 'ad',)
+            'fields': ('logo_original', 'logo_small', 'logo_small_preview', 'logo', 'logo_preview', 'ad_original', 'ad',
+                       'ad_preview',)
         }),
         ('Details', {
             'classes': ('collapse',),
@@ -25,7 +26,25 @@ class CatalogInfoAdmin(admin.ModelAdmin):
                        'job_types', 'continents', 'values', 'tags',)
         })
     )
-    readonly_fields = ('logo_small', 'logo', 'ad',)
+    readonly_fields = ('logo_small', 'logo', 'ad', 'logo_small_preview', 'logo_preview', 'ad_preview',)
+
+    def logo_small_preview(self, instance):
+        return '<img src="%s" />' % instance.logo_small.url
+
+    logo_small_preview.allow_tags = True
+    logo_small_preview.short_description = "Preview of small logo"
+
+    def logo_preview(self, instance):
+        return '<img src="%s" />' % instance.logo.url
+
+    logo_preview.allow_tags = True
+    logo_preview.short_description = "Preview of logo"
+
+    def ad_preview(self, instance):
+        return '<img src="%s" />' % instance.ad.url
+
+    ad_preview.allow_tags = True
+    ad_preview.short_description = "Preview of ad"
 
 
 @admin.register(Exhibitor)

--- a/exhibitors/admin.py
+++ b/exhibitors/admin.py
@@ -17,8 +17,7 @@ class CatalogInfoAdmin(admin.ModelAdmin):
         }),
         ('Images', {
             'classes': ('collapse',),
-            'fields': ('logo_original', 'logo_small', 'logo_small_preview', 'logo', 'logo_preview', 'ad_original', 'ad',
-                       'ad_preview',)
+            'fields': ('logo_original', 'logo_small_preview', 'logo_preview', 'ad_original', 'ad_preview',)
         }),
         ('Details', {
             'classes': ('collapse',),
@@ -26,7 +25,7 @@ class CatalogInfoAdmin(admin.ModelAdmin):
                        'job_types', 'continents', 'values', 'tags',)
         })
     )
-    readonly_fields = ('logo_small', 'logo', 'ad', 'logo_small_preview', 'logo_preview', 'ad_preview',)
+    readonly_fields = ('logo_small_preview', 'logo_preview', 'ad_preview',)
 
     def logo_small_preview(self, instance):
         return '<img src="%s" />' % instance.logo_small.url

--- a/exhibitors/admin.py
+++ b/exhibitors/admin.py
@@ -2,6 +2,7 @@ from django.contrib import admin
 
 from .models import Exhibitor, WorkField, JobType, \
     Continent, Value, CatalogInfo, Location, BanquetteAttendant
+from lib.util import image_preview
 
 
 @admin.register(CatalogInfo)
@@ -27,13 +28,6 @@ class CatalogInfoAdmin(admin.ModelAdmin):
         })
     )
     readonly_fields = ('logo_small_preview', 'logo_preview', 'ad_preview',)
-
-    def image_preview(name):
-        def f(self, instance):
-            return '<img src="%s" />' % getattr(instance, name).url
-        f.allow_tags = True
-        f.short_description = "Preview of small logo"
-        return f
 
     logo_small_preview = image_preview('logo_small')
     logo_preview = image_preview('logo')

--- a/exhibitors/admin.py
+++ b/exhibitors/admin.py
@@ -10,14 +10,15 @@ class CatalogInfoAdmin(admin.ModelAdmin):
     ordering = ('display_name',)
     fieldsets = (
         (None, {
-            'fields': ('exhibitor', 'display_name', 'slug', 'short_description',
-                       'description', 'employees_sweden', 'employees_world',
-                       'countries', 'website_url', 'facebook_url',
-                       'twitter_url', 'linkedin_url',)
+            'fields': ('exhibitor', 'display_name', 'slug',
+                       'short_description', 'description', 'employees_sweden',
+                       'employees_world', 'countries', 'website_url',
+                       'facebook_url', 'twitter_url', 'linkedin_url',)
         }),
         ('Images', {
             'classes': ('collapse',),
-            'fields': ('logo_original', 'logo_small_preview', 'logo_preview', 'ad_original', 'ad_preview',)
+            'fields': ('logo_original', 'logo_small_preview', 'logo_preview',
+                       'ad_original', 'ad_preview',)
         }),
         ('Details', {
             'classes': ('collapse',),
@@ -27,23 +28,16 @@ class CatalogInfoAdmin(admin.ModelAdmin):
     )
     readonly_fields = ('logo_small_preview', 'logo_preview', 'ad_preview',)
 
-    def logo_small_preview(self, instance):
-        return '<img src="%s" />' % instance.logo_small.url
+    def image_preview(name):
+        def f(self, instance):
+            return '<img src="%s" />' % getattr(instance, name).url
+        f.allow_tags = True
+        f.short_description = "Preview of small logo"
+        return f
 
-    logo_small_preview.allow_tags = True
-    logo_small_preview.short_description = "Preview of small logo"
-
-    def logo_preview(self, instance):
-        return '<img src="%s" />' % instance.logo.url
-
-    logo_preview.allow_tags = True
-    logo_preview.short_description = "Preview of logo"
-
-    def ad_preview(self, instance):
-        return '<img src="%s" />' % instance.ad.url
-
-    ad_preview.allow_tags = True
-    ad_preview.short_description = "Preview of ad"
+    logo_small_preview = image_preview('logo_small')
+    logo_preview = image_preview('logo')
+    ad_preview = image_preview('ad')
 
 
 @admin.register(Exhibitor)

--- a/lib/util.py
+++ b/lib/util.py
@@ -1,6 +1,15 @@
 from django.utils import timezone
 import calendar
 
+
+def image_preview(name):
+    def f(self, instance):
+        return '<img src="%s" />' % getattr(instance, name).url
+    f.allow_tags = True
+    f.short_description = 'Preview of %s' % name
+    return f
+
+
 def has_common_element(list1, list2):
     return True if set(list1) & set(list2) else False
 


### PR DESCRIPTION
Generated images can now be previewed in the admin.
It's a nice way to see what's going to be displayed in the apps and on the web site.