### PR TITLE
Fixed bug when creating new company contact

### DIFF
--- a/companies/urls.py
+++ b/companies/urls.py
@@ -10,7 +10,7 @@ urlpatterns = [
     #url(r'^edit/(?P<pk>\d+)', views.company_update, name='company_edit'),
     #url(r'^delete/(?P<pk>\d+)$', views.company_delete, name='company_delete'),
     #CRUD Company contact person
-    #url(r'^(?P<pk>\d+)/new/', views.contact_create, name='contact_new'),
+    url(r'^(?P<pk>\d+)/new/', views.contact_create, name='contact_new'),
     url(r'^contact/(?P<contact_pk>\d+)/toggle_active/', views.contact_active_toggle, 
         name='contact_toggle_active'),
 

--- a/templates/companies/contact_form.html
+++ b/templates/companies/contact_form.html
@@ -1,15 +1,9 @@
 {% extends "base.html" %}
+{% load crispy_forms_tags %}
 {% block content %}
-<form method="post">{% csrf_token %}
-{% for field in form %}
-<fieldset class="control-group">
-    <label class="control-label" for="id_{{ field.name }}">{{ field.label }}</label>
-    <div class="controls">
-        {{ field }}
-        <p class="help-text">{{ field.help_text }} </p>
-    </div>
-</fieldset>
-{% endfor %}
-    <input type="submit" value="Submit" />
+<form method="post" >
+    {% csrf_token %}
+    {{form | crispy }}
+    <input class="btn btn-primary" type="submit" value="Submit" />
 </form>
 {% endblock %}


### PR DESCRIPTION
The bug was that when in sales view for a sale (/fairs/2017/sales/2), the button for "New contact" gave server error. The url the button tried did not exist. The correct url was commented away. I uncommented correct row and added styling with crispy forms tag.

Tested the button as admin, also as "kam" user, a user with the same permissions as key account manager in ais.