### PR TITLE
Bugfix for products extra stand area and height

### DIFF
--- a/register/forms.py
+++ b/register/forms.py
@@ -394,7 +394,7 @@ class ExhibitorForm(ModelForm):
             CHECKED = 1
             UNCHECKED = 0
         # List of all checked products
-        checkedProductsList = [None]
+        checkedProductsList = []
         for order in orders:
             checkedProductsList.append(order.product)
         # create field and make sure all products that is inside the dictionary is initially checked
@@ -411,12 +411,21 @@ class ExhibitorForm(ModelForm):
             self.fields[fieldname] = self.ProductSelectChoiceField(choices=listProducts, required=False, widget=RadioSelect())
         elif widget == "Select":
             self.fields[fieldname] = self.ProductSelectChoiceField(choices=listProducts, required=False, widget=Select())
-        try:
-            # Fix for radio buttons and select to show ordered product
-            # Try/except because if there is no order, there will be indexError
-            self.initial[fieldname] = orders[0].product.name
-        except IndexError:
-            pass
+        # add preselected product if exists in database (needed for the js)
+        bFlag = False
+        for listP in listProducts:
+            for checkedP in checkedProductsList:
+                if listP[1] == checkedP.name:
+                    self.fields[fieldname].initial = listP[0]
+                    bFlag = True
+        if bFlag == False:
+            try:
+                # Fix for radio buttons and select to show ordered product
+                # Try/except because if there is no order, there will be indexError
+                self.initial[fieldname] = orders[0].product.name
+            except IndexError:
+                pass
+
         #self.fields[fieldname].initial = [p for p in checkedProductsList]
 
 


### PR DESCRIPTION
product as select field now works for db, email, js on confirm and submit and preloads form fields, that is the bug where exhibitors requesting extra stand area and height should work completely.

Things to test:
1. If products are selected and saved the summary on confirm & submit should be updated
2. The product on the db should be updated/created
3. The email should contain the correct info
4. On logging out and in the correct products should be preloded into the selection fields