### PR TITLE
Bugfix exhibitor transition year

### DIFF
--- a/register/views.py
+++ b/register/views.py
@@ -158,7 +158,7 @@ def create_exhibitor(request, template_name='register/exhibitor_form.html'):
 
             exhibitor = None
             try:
-                exhibitor = Exhibitor.objects.get(company=company)
+                exhibitor = Exhibitor.objects.get(company=company, fair=currentFair)
             except Exhibitor.DoesNotExist:
                 pass
 
@@ -253,7 +253,7 @@ def create_exhibitor(request, template_name='register/exhibitor_form.html'):
 
                 # Create or update exhibitor
                 try:
-                    exhibitor.pk = Exhibitor.objects.get(company=exhibitor.company).pk
+                    exhibitor.pk = Exhibitor.objects.get(company=exhibitor.company, fair=currentFair).pk
                     exhibitor.save()
                 except Exhibitor.DoesNotExist:
                     exhibitor.save()


### PR DESCRIPTION
See commit on Aug 09, 2017 for info,

things to do before test:
1. create a fair that is not current (i.e create a Arnada Fair 2016 and make sure the "current box" is not checked" (also make sure you have a current fair, e.g "Armada Fair 2017" or whatever you have your current fair set to, with both fairs having signup contracts else you'll get an error)
2. add an exhibitor for some test company to the fair you just created (Armada Fair 2016)
3. add som product (i.e, a stand height with some wierd spec that you connect to the fair you just created)
4. Add this product to the exhibitor you just created

Thigs to test:
log in to the cr with this exhibitor, then make sure that:
1. The order you just created is NOT seen in the form fields (only current products should be seen)
2. Upon save, make sure a new exhibitor for the same company is created but with the current fair instead (that is you should see both "<company name> at Armada Fair 2017" AND "<company name> at Armada Fair 2016" in the exhibitors view in admin
3. Make sure that when you now add orders and save, these orders are connected to the correct exhibitor and that the exhibitor with the "not current fair" is not overwritten or deleted