### PR TITLE
bugfix for exhibitors from previous years

### DIFF
--- a/register/views.py
+++ b/register/views.py
@@ -158,7 +158,7 @@ def create_exhibitor(request, template_name='register/exhibitor_form.html'):
 
             exhibitor = None
             try:
-                exhibitor = Exhibitor.objects.get(company=company)
+                exhibitor = Exhibitor.objects.get(company=company, fair=currentFair)
             except Exhibitor.DoesNotExist:
                 pass
 
@@ -253,7 +253,7 @@ def create_exhibitor(request, template_name='register/exhibitor_form.html'):
 
                 # Create or update exhibitor
                 try:
-                    exhibitor.pk = Exhibitor.objects.get(company=exhibitor.company).pk
+                    exhibitor.pk = Exhibitor.objects.get(company=exhibitor.company, fair=currentFair).pk
                     exhibitor.save()
                 except Exhibitor.DoesNotExist:
                     exhibitor.save()


### PR DESCRIPTION
Fixes issue where
1. Exhibitors from previous year gets overwritten
2. Exhibitor from previous year get products from precious year inlined with the new ones
(i.e with this fix it should be so that, a new exhibitor for this years fair is created, still keeping the old exhibitor at precious years fair in the db, where the correct products are loaded into the cr)

Things to do before test ON ais2 (not on ais hehe):
1. Create a test user (preferrably with your real email so you can verify the confirm mail later)
2. Connect test user to a company from last years fair that is already an exhibitor (a company that is an exhibitor at Armada 2016)
3. If doesNotExist any products, add some in the exhibitors view at ais2.armada.nu/fairs/2016 (for example extra stand area for fair 2016)

Things to test:
1. Login to ais2.armada.nu/register with your test user and check that no products are loaded into the fields from previous year
2. Press save, then go into ais2.armada.nu/fairs/2016/exhibitors and make sure that exhibitor still exists and has its products
3. go to ais2.armada.nu/fairs/2017/exhibitors and check that the exhibitor base kit for 39500 sek is added
4. log into cr and add some products, press save, go to confirm tab and make sure that the summary (js) contains the correct info, then submit and check that the email contains the correct info
5. Finally go back again to ais2.armada.nu/fairs/2017/exhibitors and make sure the orders are correct

That should be all test necessary, write me on slack or in this pr if anything is wrong or if i have missed something!