### PR TITLE
Script to fix db

### DIFF
--- a/scripts/orders-bugfix.py
+++ b/scripts/orders-bugfix.py
@@ -12,7 +12,7 @@ faulty_orders = Order.objects.filter(exhibitor__in = current_exhibitor, product_
 
 for o in faulty_orders:
 	company = o.exhibitor.company 
-	existing_exhibitor = Exhibitor.objects.filter(fair = Fair.objects.get(current = False), company = company)
+	existing_exhibitor = Exhibitor.objects.filter(fair = Fair.objects.get(year = 2016), company = company)
 	
 	if existing_exhibitor.exists():
 		last_year_exhibitor = list(existing_exhibitor)[0]

--- a/scripts/orders-bugfix.py
+++ b/scripts/orders-bugfix.py
@@ -17,7 +17,7 @@ for o in faulty_orders:
 	if existing_exhibitor.exists():
 		last_year_exhibitor = list(existing_exhibitor)[0]
 	else: 
-		last_year_exhibitor = Exhibitor(fair = Fair.objects.get(year = 2016), company = company, about = "This exhibitor is incomplete due to a bug in 2017. The orders are complete.")
+		last_year_exhibitor = Exhibitor(fair = Fair.objects.get(year = 2016), company = company, about_text = "This exhibitor is incomplete due to a bug in 2017. The orders are complete.")
 		last_year_exhibitor.save()
 	o.exhibitor = last_year_exhibitor
 	o.save()

--- a/scripts/orders-bugfix.py
+++ b/scripts/orders-bugfix.py
@@ -1,0 +1,23 @@
+# This script is only made for fixing the db after a bug in 2017. The problem was that some orders was connected to an exhibior from the current year, 
+# but contained products from last year. The last year exhibitor had been overwritten by the current year. This script creates a new exhibitor for the company, 
+# connected to the fair 2016 (last years fair in writing moment) and connects the orders with products connected to the fair 2016, to that exhibitor.
+
+from orders.models import Order, Product
+from exhibitors.models import Exhibitor
+from fair.models import Fair
+
+not_current_products = Product.objects.filter(fair = Fair.objects.get(year = 2016))
+current_exhibitor = Exhibitor.objects.filter(fair = Fair.objects.get(current = True))
+faulty_orders = Order.objects.filter(exhibitor__in = current_exhibitor, product__in = not_current_products)
+
+for o in faulty_orders:
+	company = o.exhibitor.company 
+	existing_exhibitor = Exhibitor.objects.filter(fair = Fair.objects.get(current = False), company = company)
+	
+	if existing_exhibitor.exists():
+		last_year_exhibitor = list(existing_exhibitor)[0]
+	else: 
+		last_year_exhibitor = Exhibitor(fair = Fair.objects.get(year = 2016), company = company, about = "This exhibitor is incomplete due to a bug in 2017. The orders are complete.")
+		last_year_exhibitor.save()
+	o.exhibitor = last_year_exhibitor
+	o.save()


### PR DESCRIPTION
Adds a script that will fix faulty orders in the db (due to an earlier bug).

Problem: In the db there are some orders from last year where the exhibitor is from this year and the product is from last year.
Reason: When a company submitted pr, the exhibitor from last year was overwritten and last year orders were connected to this year exhibitor. This bug is now solved.
Test:
In admin-view: Create an exhibitor for this year. Create a product for last year and one for this year.  Create following orders:
Two that is connected to this year exhibitor and last year product.
One that is connected to this year exhibitor and this years product.
One that is connected to last year product and last year exhibitor.
Run script.
Check that only one new exhibitor is created and that both faulty orders are connected to that exhibitor. The other orders should remain as before. 
