### PR TITLE
closes cr for exhibitors

### DIFF
--- a/register/forms.py
+++ b/register/forms.py
@@ -163,7 +163,9 @@ class ExhibitorForm(ModelForm):
 
         # time params for warning or close cr
         self.timeFlag = kwargs.pop('timeFlag')
-        self.time_disp = kwargs.pop('time_disp')
+        time_disp = kwargs.pop('time_disp')
+        self.time_end = time_disp[0]
+        self.time_diff = time_disp[1]
 
         super(ExhibitorForm, self).__init__(*args, **kwargs)
 

--- a/register/forms.py
+++ b/register/forms.py
@@ -14,6 +14,7 @@ from exhibitors.models import Exhibitor, CatalogInfo
 from companies.models import Company, Contact
 
 from enum import Enum
+import datetime
 
 class LoginForm(AuthenticationForm):
     def __init__(self, *args, **kwargs):
@@ -159,6 +160,10 @@ class ExhibitorForm(ModelForm):
         matching_survey = kwargs.pop('matching_survey')
         matching_questions = kwargs.pop('matching_questions')
         matching_responses = kwargs.pop('matching_responses')
+
+        # time params for warning or close cr
+        self.timeFlag = kwargs.pop('timeFlag')
+        self.time_disp = kwargs.pop('time_disp')
 
         super(ExhibitorForm, self).__init__(*args, **kwargs)
 
@@ -436,7 +441,6 @@ class ExhibitorForm(ModelForm):
                         mark_safe(product.name),
                         mark_safe(product.description),
                     )
-
 
     # Returns a generator/iterator with all product fields where you choose an amount.
     # Choose a prefix to get which the correct type, e.g 'banquet_', or 'event_'.

--- a/register/views.py
+++ b/register/views.py
@@ -26,16 +26,19 @@ from .forms import CompanyForm, ContactForm, RegistrationForm, CreateContactForm
 
 BASE_PRICE = 39500
 # end time for cr
-END_TIME =  datetime.datetime(2017,9,4,23,59)
+END_TIME =  datetime.datetime(2017,8,4,23,59)
+END_TIME_CLOSE = datetime.datetime(2017,8,14,23,59)
 
 
 def getTimeFlag():
     # used to close cr
     time = datetime.datetime.now().replace(microsecond=0)
     if time < END_TIME:
-        return('warning', END_TIME - time)
+        return('warning', [END_TIME, END_TIME - time])
+    elif time > END_TIME and time < END_TIME_CLOSE:
+        return('overdue', [END_TIME, time - END_TIME])
     else:
-        return('closed', END_TIME)
+        return('closed', [END_TIME, time - END_TIME])
 
 
 def index(request, template_name='register/index.html'):

--- a/register/views.py
+++ b/register/views.py
@@ -13,6 +13,8 @@ import math
 import json
 import requests as r
 
+import datetime
+
 from companies.models import Company, Contact
 from orders.models import Product, Order, ProductType
 from exhibitors.models import Exhibitor
@@ -23,8 +25,17 @@ from .models import SignupContract, SignupLog
 from .forms import CompanyForm, ContactForm, RegistrationForm, CreateContactForm, UserForm, InterestForm, ExhibitorForm, ChangePasswordForm
 
 BASE_PRICE = 39500
+# end time for cr
+END_TIME =  datetime.datetime(2017,9,4,23,59)
 
 
+def getTimeFlag():
+    # used to close cr
+    time = datetime.datetime.now().replace(microsecond=0)
+    if time < END_TIME:
+        return('warning', END_TIME - time)
+    else:
+        return('closed', END_TIME)
 
 
 def index(request, template_name='register/index.html'):
@@ -33,7 +44,8 @@ def index(request, template_name='register/index.html'):
             return redirect('anmalan:home')
         else:
             return redirect('anmalan:logout')
-    return render(request, template_name)
+    timeFlag, time_disp = getTimeFlag()
+    return render(request, template_name, {'timeFlag': timeFlag, 'time_disp': time_disp})
 
 def home(request, template_name='register/home.html'):
     if request.user.is_authenticated():
@@ -187,6 +199,10 @@ def create_exhibitor(request, template_name='register/exhibitor_form.html'):
             matching_questions = Question.objects.filter(survey=matching_survey)
             # check which questions are already answered
             current_matching_responses = Response.objects.filter(exhibitor=exhibitor, survey=matching_survey)
+
+            # Set automated time closing of cr
+            timeFlag, time_disp = getTimeFlag()
+
             # Pass along all relevant information to form
             form = ExhibitorForm(
                 request.POST or None,
@@ -211,6 +227,8 @@ def create_exhibitor(request, template_name='register/exhibitor_form.html'):
                 matching_survey = matching_survey,
                 matching_questions = matching_questions,
                 matching_responses = current_matching_responses,
+                timeFlag = timeFlag,
+                time_disp = time_disp,
             )
 
             if form.is_valid():

--- a/templates/register/exhibitor_form.html
+++ b/templates/register/exhibitor_form.html
@@ -35,25 +35,31 @@
         {% if form.timeFlag == 'warning' %}
             <br>
             <li class="nav">
-                <p class="text-danger"> Note that the complete registration for THS Armada closes in {{ form.time_disp }}. </p>
+                <p class="text-danger"> Note that the complete registration for THS Armada closes on {{form.time_end }} - that is in {{ form.time_diff }}. </p>
             </li>
-        {% elif form.timeFlag == 'closed' %}
-            <br/>
-            <li class="nav">
-                <h4 class="text-danger">
-                    The complete registration for THS Armada closed on {{ form.time_disp }}
-                </h4>
-            </li>
+        {% elif form.timeFlag == 'closed' or form.timeFlag == 'overdue' %}
             <br/>
             <li class="nav">
                 <p class="text-danger">
+                    The complete registration for THS Armada closed on {{ form.time_end }} , you are overdue by {{ form.time_diff }} .
+                </p>
+            </li>
+            <br/>
+            <li class="nav">
+            {% if form.timeFlag == 'overdue' %}
+                <p class="text-danger">
+                    You may still proceed to make changes, but we can not guarantee that they will be applied. If you have any questions please contact your sales responsible.
+                </p>
+            {% elif form.timeFlag == 'closed' %}
+                <p class="text-danger">
                     You are no longer granted permission to make any changes. If you have any questions please contact your sales responsible.
                 </p>
+            {% endif %}
             </li>
         {% endif %}
       </ul>
-      {% if form.timeFlag == 'danger' %}
-
+      {% if form.timeFlag == 'overdue' or form.timeFlag == 'closed' %}
+        <br /> <br />
       {% endif %}
 
       <!-- EXHIBITOR FORM -->

--- a/templates/register/exhibitor_form.html
+++ b/templates/register/exhibitor_form.html
@@ -32,7 +32,29 @@
         <li class="nav" id="confirm-li"><a href="#confirm-and-submit" data-toggle="tab">Confirm &amp; Submit</a></li>
         <li class="nav"> | </li>
         <li class="nav"><a href="{% url 'anmalan:logout' %}">Logout</a></li>
+        {% if form.timeFlag == 'warning' %}
+            <br>
+            <li class="nav">
+                <p class="text-danger"> Note that the complete registration for THS Armada closes in {{ form.time_disp }}. </p>
+            </li>
+        {% elif form.timeFlag == 'closed' %}
+            <br/>
+            <li class="nav">
+                <h4 class="text-danger">
+                    The complete registration for THS Armada closed on {{ form.time_disp }}
+                </h4>
+            </li>
+            <br/>
+            <li class="nav">
+                <p class="text-danger">
+                    You are no longer granted permission to make any changes. If you have any questions please contact your sales responsible.
+                </p>
+            </li>
+        {% endif %}
       </ul>
+      {% if form.timeFlag == 'danger' %}
+
+      {% endif %}
 
       <!-- EXHIBITOR FORM -->
       <form method="post" enctype="multipart/form-data">{% csrf_token %}
@@ -836,13 +858,14 @@
         <!-- Form next, back and save btn, and errors -->
         <div class="form-footer cr-nav-common cr-nav-bottom">
           <a class="btn btn-armada btn-armada-green btnBack" id="back-button">Back</a>
-          <span class="has-popover" data-content="You only need to save before closing your browser window", data-placement='top', data-container="body">
-            <button type="submit" name="save" class="btn btn-armada btn-armada-green" id="save-button">Save</button>
-          </span>
-
-          <span class="has-popover" data-content="Submit your application to Armada 2017", data-placement='top', data-container="body">
-          <button type="submit" name="submit" class="btn btn-armada" id="submit-button">Submit</button>
-          </span>
+          {% if form.timeFlag != 'closed' %}
+              <span class="has-popover" data-content="You only need to save before closing your browser window", data-placement='top', data-container="body">
+                <button type="submit" name="save" class="btn btn-armada btn-armada-green" id="save-button">Save</button>
+              </span>
+              <span class="has-popover" data-content="Submit your application to Armada 2017", data-placement='top', data-container="body">
+              <button type="submit" name="submit" class="btn btn-armada" id="submit-button">Submit</button>
+              </span>
+          {% endif %}
           <a class="btn btn-armada btn-armada-green btnNext" id="next-button">Next</a>
           <div>{{ form.non_field_errors }}</div>
         </div>

--- a/templates/register/index.html
+++ b/templates/register/index.html
@@ -10,7 +10,7 @@
 </head>
 
 <body>
-    <div class="container">   
+    <div class="container">
         <div class="row">
             <div class="headline">
                 <svg viewBox="305 16 320 150" width="555px" height="250px" version="1.1">
@@ -22,6 +22,11 @@
         <div class="row">
             <div class="col-md-12">
                 <div class="text-center form-container">
+                    {% if timeFlag == 'warning' %}
+                        <h4 class="text-danger"> The complete registration for THS Armada closes in {{ time_disp }}. </h4>
+                    {% elif timeFlag == 'closed' %}
+                        <h4 class="text-danger"> The complete registration was closed on {{ time_disp }} </h4>
+                    {% endif %}
                     <a href="{% url 'anmalan:login' %}" class="btn-signin btn-green">Sign in</a>
                     <div>
                         <svg viewBox="50 50 200 200" width="100px" height="100px" version="1.1">
@@ -30,7 +35,7 @@
                     </div>
                 </div>
             </div>
-        </div> 
+        </div>
     </div>
 </body>
 


### PR DESCRIPTION
... om time variable in register/views.py on line 29. Setting this variable downwind in time a warning of "x time remains before cr closes" on both index and when logged in as exhibitor. setting the variable upwind should display a "cr closed on x" message on both index and logged in page, also should remove save and submit buttons so that the companies still can view their submissions but not change them and save. Might need some css and spell checking!

Note: doing this PR to master since ais2 is down (and has been all day)!