### PR TITLE
Csv exhibitor + admin views

### DIFF
--- a/events/admin.py
+++ b/events/admin.py
@@ -103,7 +103,10 @@ class EventAdmin(admin.ModelAdmin):
             'fields': ('tags',)
         })
     )
-    list_filter = ('published', 'registration_required',)
+    search_fields = ('name',)
+    # order by fair in first hand
+    ordering = ('fair', 'name',)
+    list_filter = ('published', 'registration_required', 'fair',)
     readonly_fields = ('event_image_preview', 'extra_field',)
     inlines = [QuestionInline]
     filter_horizontal = ("allowed_groups",)

--- a/exhibitors/admin.py
+++ b/exhibitors/admin.py
@@ -46,16 +46,21 @@ def export_exhibitor_as_csv(modeladmin, request, queryset):
 
     csv_headers = [
         'company', 'stand_location',
+        'requests_for_stand_placement', 'requests_for_exhibition_area', 
+        'interested_in_armada_transport',
         'transport_to_fair_type', 'number_of_packages_to_fair', 'number_of_pallets_to_fair',
-        'estimated_arrival', 'transport_from_fair_type', 'number_of_packages_from_fair',
+        'estimated_arrival', 
+        'transport_from_fair_type', 'number_of_packages_from_fair',
         'number_of_pallets_from_fair',
         'transport_from_fair_address', 'transport_from_fair_zip_code', 'transport_from_fair_recipient_name',
         'transport_from_fair_recipient_phone_number',
         'heavy_duty_electric_equipment', 'other_information_about_the_stand',
     ]
 
+    # the list of products is not fair specific
     for product in Product.objects.all():
-        csv_headers.append(product.name)
+        prodName = product.name + ' (' + str(product.fair.year) + ')'
+        csv_headers.append(prodName)
 
     writer = csv.writer(response)
     writer.writerow(csv_headers)
@@ -63,10 +68,15 @@ def export_exhibitor_as_csv(modeladmin, request, queryset):
         csv_row = [
             exhibitor.company.name,
             exhibitor.location.name if exhibitor.location else '',
+            exhibitor.requests_for_stand_placement,
+            exhibitor.requests_for_exhibition_area,
+
+            exhibitor.interested_in_armada_transport,
             exhibitor.transport_to_fair_type,
             exhibitor.number_of_packages_to_fair,
             exhibitor.number_of_pallets_to_fair,
             exhibitor.estimated_arrival,
+
             exhibitor.transport_from_fair_type,
             exhibitor.number_of_packages_from_fair,
             exhibitor.number_of_pallets_from_fair,
@@ -92,8 +102,10 @@ def export_exhibitor_as_csv(modeladmin, request, queryset):
 @admin.register(Exhibitor)
 class ExhibitorAdmin(admin.ModelAdmin):
     search_fields = ('company__name',)
-    ordering = ('company',)
-    list_filter = ('status',)
+    # order by fair in first hand
+    ordering = ('-fair__year', 'company',)
+    # filters to filter search query
+    list_filter = ('status', 'requests_for_stand_placement', 'requests_for_exhibition_area', 'transport_to_fair_type', 'transport_from_fair_type', 'fair',)
 
     actions = [export_exhibitor_as_csv]
 

--- a/orders/admin.py
+++ b/orders/admin.py
@@ -2,7 +2,20 @@ from django.contrib import admin
 
 from .models import Product, Order, ProductType
 
-admin.site.register(Product)
-admin.site.register(Order)
+@admin.register(Order)
+class OrderAdmin(admin.ModelAdmin):
+    """ Orders are ordered by fair in first hand, then by exhibitor name. It's possible to filter order by product fair, and search for exhibitor name and product name"""
+    search_fields = ('exhibitor__company__name', 'product__name')
+    ordering = ('product__fair', 'exhibitor__company__name',)
+    list_filter = ('product__fair__year', )
+
+@admin.register(Product)
+class ProductAdmin(admin.ModelAdmin):
+    search_fields = ('name',)
+    ordering = ('-fair__year', 'name',)
+    list_filter = ('fair', )
+
+#admin.site.register(Product)
+#admin.site.register(Order)
 admin.site.register(ProductType)
 # Register your models here.

--- a/register/admin.py
+++ b/register/admin.py
@@ -31,15 +31,17 @@ def export_signup_as_csv(modeladmin, request, queryset):
 # Overrides admin register to add custom actions
 @admin.register(SignupLog)
 class SignupLogAdmin(admin.ModelAdmin):
-    search_fields = ('company__name',)
-    ordering = ('company',)
+    search_fields = ('company__name', 'timestamp')
+    ordering = ('-timestamp',)
+    list_filter = ('type', )
 
     actions = [export_signup_as_csv]
 
 @admin.register(OrderLog)
 class OrderLogAdmin(admin.ModelAdmin):
-    search_fields = ('company__name',)
-    ordering = ('fair',)
+    search_fields = ('company__name', 'timestamp',)
+    ordering = ('-timestamp',)
+    list_filter = ('action', 'fair')
 
 # Register your models here.
 admin.site.register(SignupContract)


### PR DESCRIPTION
Updated exhibitor csv function to include some more fields and added filter and sort options to multiple admin views.
Test:
- go to http://localhost:8000/admin/exhibitors/exhibitor/ and try some of the filter to the right (escpecially the fair)
- check the checkboxes for a couple of exhibitors (preferrable some you know have done some choices in their exhibitor application) and chose the action 'export as csv'. Open the downloaded csv file and compare result with those exhibitors application
- go to admin/events/event/ and try the filters. Make sure the ordering is fair first, then event name
- go to admin/orders/order/ and try the filters. Make sure the ordering is fair first, then exhibitor name. You should be able to search both for product and exhibitor name
- go to admin/orders/product and try the filters. Make sure the ordering is fair first, then product name
- go to admin/register/orderlog/ and try the filters. Make sure the ordering is date (newest first)