### PR TITLE
Make banquette placement only return for current year

### DIFF
--- a/api/views.py
+++ b/api/views.py
@@ -13,7 +13,7 @@ from events.models import Event
 from exhibitors.models import Exhibitor, CatalogInfo
 from fair.models import Partner
 from news.models import NewsArticle
-from exhibitors.models import BanquetteAttendant
+from banquet.models import BanquetteAttendant
 from fair.models import Fair
 
 def root(request):

--- a/api/views.py
+++ b/api/views.py
@@ -110,11 +110,11 @@ def status(request):
 def banquet_placement(request):
     '''
     Returns all banquet attendance. 
-    The field hob_title depends on weather a attendant is a user or exhibitor.
+    The field job_title depends on weather a attendant is a user or exhibitor.
     '''
     # Tables and seats are mocked with this index, remove when implemented
     index = 0
-    banquet_attendees = BanquetteAttendant.objects.all()
+    banquet_attendees = BanquetteAttendant.objects.filter(fair=Fair.objects.get(current=True))
 
     from recruitment.models import RecruitmentApplication
     recruitment_applications = RecruitmentApplication.objects.filter(status='accepted')


### PR DESCRIPTION
When testing in ais2 I saw that I had missed to make api/banquette_placement to only return for the current year. 
Test:
Create one attendant for the current fair and one for another fair. Go to api/banquette_placement and make sure only the attendant for this year is shown.