### PR TITLE
Banquet app

### DIFF
--- a/ais_static/js/banquet_attendant.js
+++ b/ais_static/js/banquet_attendant.js
@@ -1,0 +1,4 @@
+$('#id_user').change(function(){
+  let user_name = $(this).val());
+  $('#id_first_name').val(user_name);
+});

--- a/banquet/forms.py
+++ b/banquet/forms.py
@@ -5,10 +5,18 @@ from django import forms
 
 from django.contrib.auth.forms import UserCreationForm, AuthenticationForm, PasswordChangeForm, PasswordResetForm, SetPasswordForm
 from django.contrib.auth.models import User
+from .models import BanquetteAttendant
 
 from enum import Enum
 import datetime
 
 # MODEL IMPORTS
 from fair.models import Fair
+from .models import BanquetteAttendant
 from exhibitors.models import Exhibitor, CatalogInfo
+
+class BanquetteAttendantForm(ModelForm):
+    class Meta:
+        model = BanquetteAttendant
+        fields = '__all__'
+        exclude = ('fair',)

--- a/banquet/forms.py
+++ b/banquet/forms.py
@@ -20,3 +20,9 @@ class BanquetteAttendantForm(ModelForm):
         model = BanquetteAttendant
         fields = '__all__'
         exclude = ('fair',)
+
+class ExternalBanquetSignupForm(ModelForm):
+    class Meta:
+        model = BanquetteAttendant
+        fields = '__all__'
+        exclude = ('fair','user', 'exhibitor', 'table_name', 'seat_number', 'ignore_from_placement')

--- a/banquet/urls.py
+++ b/banquet/urls.py
@@ -6,6 +6,7 @@ urlpatterns = [
     url(r'^$', views.banquet_attendants, name='banquet'),
 	url(r'^attendant/(?P<pk>\d+)/$', views.banquet_attendant, name='banquet/attendant'),
 	url(r'^attendant/new$', views.new_banquet_attendant, name='banquet/new'),
+    url(r'^signup$', views.banquet_external_signup, name='banquet/signup'),
 	#url(r'^(?P<exhibitor_pk>\d+)/banquette_attendant/(?P<instance_pk>\d+)$', views.related_object_form(BanquetteAttendant, 'Banquet attendant', 'banquette_attendant_delete'), name='banquette_attendant'),
 	#url(r'^(?P<exhibitor_pk>\d+)/banquette_attendant/(?P<instance_pk>\d+)/delete$', views.related_object_delete(BanquetteAttendant), name='banquette_attendant_delete'),
 	#url(r'^(?P<exhibitor_pk>\d+)/contact/(?P<instance_pk>\d+)$', views.related_object_form(Contact, 'Contact', None), name='contact'),

--- a/banquet/urls.py
+++ b/banquet/urls.py
@@ -7,6 +7,7 @@ urlpatterns = [
 	url(r'^attendant/(?P<pk>\d+)/$', views.banquet_attendant, name='banquet/attendant'),
 	url(r'^attendant/new$', views.new_banquet_attendant, name='banquet/new'),
     url(r'^signup$', views.banquet_external_signup, name='banquet/signup'),
+    url(r'^thankyou$', views.thank_you, name='banquet/thankyou'),
 	#url(r'^(?P<exhibitor_pk>\d+)/banquette_attendant/(?P<instance_pk>\d+)$', views.related_object_form(BanquetteAttendant, 'Banquet attendant', 'banquette_attendant_delete'), name='banquette_attendant'),
 	#url(r'^(?P<exhibitor_pk>\d+)/banquette_attendant/(?P<instance_pk>\d+)/delete$', views.related_object_delete(BanquetteAttendant), name='banquette_attendant_delete'),
 	#url(r'^(?P<exhibitor_pk>\d+)/contact/(?P<instance_pk>\d+)$', views.related_object_form(Contact, 'Contact', None), name='contact'),

--- a/banquet/urls.py
+++ b/banquet/urls.py
@@ -4,9 +4,8 @@ from .models import BanquetteAttendant
 
 urlpatterns = [
     url(r'^$', views.banquet_attendants, name='banquet'),
-	#url(r'^(?P<pk>\d+)/$', views.banquet_attendant, name='banquet'),
-    
-	#url(r'^(?P<exhibitor_pk>\d+)/banquette_attendant/new$', views.related_object_form(BanquetteAttendant, 'Banquet attendant', 'banquette_attendant_delete'), name='banquette_attendant_new'),
+	url(r'^attendant/(?P<pk>\d+)/$', views.banquet_attendant, name='banquet/attendant'),
+	url(r'^attendant/new$', views.new_banquet_attendant, name='banquet/new'),
 	#url(r'^(?P<exhibitor_pk>\d+)/banquette_attendant/(?P<instance_pk>\d+)$', views.related_object_form(BanquetteAttendant, 'Banquet attendant', 'banquette_attendant_delete'), name='banquette_attendant'),
 	#url(r'^(?P<exhibitor_pk>\d+)/banquette_attendant/(?P<instance_pk>\d+)/delete$', views.related_object_delete(BanquetteAttendant), name='banquette_attendant_delete'),
 	#url(r'^(?P<exhibitor_pk>\d+)/contact/(?P<instance_pk>\d+)$', views.related_object_form(Contact, 'Contact', None), name='contact'),

--- a/banquet/views.py
+++ b/banquet/views.py
@@ -53,7 +53,7 @@ def new_banquet_attendant(request, year, template_name='banquet/banquet_attendan
     # not authenticated:
     return render(request, 'login.html', {'next': next, 'fair': fair})
 
-def banquet_external_signup(request, year, template_name='banquet/banquet_attendant.html'):
+def banquet_external_signup(request, year, template_name='banquet/external_signup.html'):
     fair = get_object_or_404(Fair, year=year)
 
     banquet_instance = None
@@ -77,3 +77,7 @@ def banquet_external_signup(request, year, template_name='banquet/banquet_attend
         banquet_attendant.save()
         return render(request, 'banquet/thank_you.html', {'fair': fair })
     return render(request, template_name, {'form': form, 'fair': fair })
+
+def thank_you(request, year, template_name='banquet/thank_you.html'):
+    fair = get_object_or_404(Fair, year=year)
+    return render(request, 'banquet/thank_you.html', {'fair': fair })

--- a/banquet/views.py
+++ b/banquet/views.py
@@ -1,7 +1,7 @@
 from django.forms import modelform_factory
 from django.shortcuts import render, redirect, get_object_or_404
 from .models import BanquetteAttendant
-from .forms import BanquetteAttendantForm
+from .forms import BanquetteAttendantForm, ExternalBanquetSignupForm
 from django.urls import reverse
 from fair.models import Fair
 
@@ -52,3 +52,28 @@ def new_banquet_attendant(request, year, template_name='banquet/banquet_attendan
 
     # not authenticated:
     return render(request, 'login.html', {'next': next, 'fair': fair})
+
+def banquet_external_signup(request, year, template_name='banquet/banquet_attendant.html'):
+    fair = get_object_or_404(Fair, year=year)
+
+    banquet_instance = None
+    user = None
+    if request.user.is_authenticated():
+        try:
+            user = request.user
+            banquet_instance = BanquetteAttendant.objects.get(user=user)
+        except BanquetteAttendant.DoesNotExist:
+            pass
+
+    form = ExternalBanquetSignupForm(
+        request.POST or None,
+        instance = banquet_instance,
+    )
+
+    if form.is_valid():
+        banquet_attendant = form.save(commit=False)
+        banquet_attendant.fair = fair
+        banquet_attendant.user = user
+        banquet_attendant.save()
+        return render(request, 'banquet/thank_you.html', {'fair': fair })
+    return render(request, template_name, {'form': form, 'fair': fair })

--- a/banquet/views.py
+++ b/banquet/views.py
@@ -1,6 +1,7 @@
 from django.forms import modelform_factory
 from django.shortcuts import render, redirect, get_object_or_404
-from banquet.models import BanquetteAttendant
+from .models import BanquetteAttendant
+from .forms import BanquetteAttendantForm
 from django.urls import reverse
 from fair.models import Fair
 
@@ -13,4 +14,41 @@ def banquet_attendants(request, year, template_name='banquet/banquet_attendants.
             'fair': fair
         })
 
+    return render(request, 'login.html', {'next': next, 'fair': fair})
+
+def banquet_attendant(request, year, pk, template_name='banquet/banquet_attendant.html'):
+    fair = get_object_or_404(Fair, year=year)
+    banquet_attendant = get_object_or_404(BanquetteAttendant, fair=fair, pk=pk)
+
+    if request.user.is_authenticated():
+        form = BanquetteAttendantForm(
+            request.POST or None,
+            instance=banquet_attendant,
+        )
+        if form.is_valid():
+            banquet_attendant = form.save(commit=False)
+            banquet_attendant.fair = fair
+            banquet_attendant.save()
+            return render(request, template_name, {'form': form, 'fair': fair })
+        return render(request, template_name, {'form': form, 'fair': fair })
+
+    # not authenticated:
+    return render(request, 'login.html', {'next': next, 'fair': fair})
+
+def new_banquet_attendant(request, year, template_name='banquet/banquet_attendant.html'):
+    fair = get_object_or_404(Fair, year=year)
+
+    if request.user.is_authenticated():
+        form = BanquetteAttendantForm(
+            request.POST or None,
+            instance=None,
+        )
+        if form.is_valid():
+            banquet_attendant = form.save(commit=False)
+            banquet_attendant.fair = fair
+            banquet_attendant.save()
+            return render(request, template_name, {'form': form, 'fair': fair })
+        return render(request, template_name, {'form': form, 'fair': fair })
+
+    # not authenticated:
     return render(request, 'login.html', {'next': next, 'fair': fair})

--- a/root/urls.py
+++ b/root/urls.py
@@ -5,5 +5,5 @@ urlpatterns = [
     url(r'^$', views.index, name='home'),
     url(r'^banquet_signup$', views.banquette_signup, name='banquette_signup'),
     url(r'^banquet_signup_delete$', views.banquette_signup_delete, name='banquette_signup_delete'),
-    #url(r'^banquet_attendants', views.banquet_attendants, name='banquet_attendants'),
+    url(r'^banquet_attendants', views.banquet_attendants, name='banquet_attendants'),
 ]

--- a/static/js/banquet_attendant.js
+++ b/static/js/banquet_attendant.js
@@ -1,0 +1,4 @@
+$("#id_user").change(function(){
+  let user_name = $(this).val());
+  $('#id_first_name').val(user_name);
+});

--- a/templates/banquet/banquet_attendant.html
+++ b/templates/banquet/banquet_attendant.html
@@ -1,4 +1,5 @@
 {% extends "base.html" %}
+{% load staticfiles %}
 {% load crispy_forms_tags %}
 {% block content %}
   <div class="row">
@@ -11,4 +12,5 @@
       </form>
     </div>
   </div>
+  <script src="{% static 'js/banquet_attendant.js' %}" type="text/javascript" charset="utf-8"></script>
 {% endblock %}

--- a/templates/banquet/banquet_attendant.html
+++ b/templates/banquet/banquet_attendant.html
@@ -11,5 +11,4 @@
       </form>
     </div>
   </div>
-  <!--<script src="{% static 'js/banquet_attendant.js' %}" type="text/javascript" charset="utf-8"></script>-->
 {% endblock %}

--- a/templates/banquet/banquet_attendant.html
+++ b/templates/banquet/banquet_attendant.html
@@ -1,0 +1,15 @@
+{% extends "base.html" %}
+{% load crispy_forms_tags %}
+{% block content %}
+  <div class="row">
+    <div class="col-md-12">
+      <form method="post">
+        <h3>Banquet Attendant</h3>
+        {% csrf_token %}
+        {{ form|crispy }}
+        <button type="submit" class="save btn btn-default">Save</button>
+      </form>
+    </div>
+  </div>
+  <!--<script src="{% static 'js/banquet_attendant.js' %}" type="text/javascript" charset="utf-8"></script>-->
+{% endblock %}

--- a/templates/banquet/banquet_attendants.html
+++ b/templates/banquet/banquet_attendants.html
@@ -22,11 +22,7 @@
         {% for attendant in banquet_attendants %}
             <tr>
                 <td>
-                    {% if attendant.user %}
-                        <a href="{% url 'view_person' fair.year attendant.user.pk %}">{{ attendant.first_name }} {{ attendant.last_name }}</a>
-                    {% else %}
-                        {{ attendant.first_name }} {{ attendant.last_name }}
-                    {% endif %}
+                    <a href="{% url 'banquet/attendant' fair.year attendant.pk %}">{{ attendant.first_name }} {{ attendant.last_name }}</a>
                 </td>
 
                 <td>{{ attendant.get_gender_display }}</td>

--- a/templates/banquet/banquet_attendants.html
+++ b/templates/banquet/banquet_attendants.html
@@ -3,6 +3,9 @@
 
 {% block content %}
     <h1>Banquet attendants ({{ banquet_attendants|length }})</h1>
+    <a href="{% url 'banquet/new' fair.year %}" class="btn btn-primary">
+      <span class="glyphicon glyphicon-plus"></span> New attendant
+    </a>
     <div class="table-responsive">
     <table class="table" id="exhibitor_table">
         <thead>

--- a/templates/banquet/external_signup.html
+++ b/templates/banquet/external_signup.html
@@ -13,23 +13,40 @@
     <div class="container">
         <div class="row">
             <div class="text-center headline">
-                <h1 class="big big-margin-top">Thank you</h1>
-                <h2>For your registration for the THS armada Banquet {{ fair.year }}!</h2>
-                <h4>If you need to change any information in your registration you can do so by visiting this page again.</h4>
+                <h1 class="big big-margin-top">THS Armada Banquet</h1>
+                <h2>Sign up for the Banquet NOW!</h2>
             </div>
         </div>
+
         <div class="row">
             <div class="col-md-12">
-                <div class="text-center form-container">
-                    <a href="{% url 'banquet/signup' fair.year %}" class="btn-signin btn-green">Back</a>
+                <form method="post" class="text-center form-container">
+                    {% csrf_token %}
+                    {{ form|crispy }}
+                    <button type="submit" class="save btn btn-default">Submit</button>
+                    {% if form.errors %}
+                      {% for field in form %}
+                        {% for error in field.errors %}
+                          <div class="alert alert-danger">
+                            <strong>{{ error|escape }}</strong>
+                          </div>
+                        {% endfor %}
+                      {% endfor %}
+                      {% for error in form.non_field_errors %}
+                        <div class="alert alert-danger">
+                          <strong>{{ error|escape }}</strong>
+                        </div>
+                      {% endfor %}
+                    {% endif %}
                     <div>
                         <svg viewBox="50 50 200 200" width="100px" height="100px" version="1.1">
                             <image xlink:href="{% static 'images/armada_logo_text_left_green.svg' %}" alt="Armada" height="300px" width="700px"/>
                         </svg>
                     </div>
-                </div>
+                </form>
             </div>
         </div>
     </div>
 </body>
+
 </html>

--- a/templates/banquet/thank_you.html
+++ b/templates/banquet/thank_you.html
@@ -1,0 +1,4 @@
+{% extends "base.html" %}
+{% block content %}
+  <h3>Thank you for signing up!</h3>
+{% endblock %}


### PR DESCRIPTION
New BanquetAttendant model in banquet app. Not much to test or check. All connections to the old model has been changed. (((((((( This is already in AIS2! ))))))

What is new and what can you check:

1. You can view all banquet attendants from current year ONLY in fairs/{year}/banquet. 
2. Click on an attendant's name to view/edit the attendant in the url fairs/{year}/banquet/attendant/{pk}.
3. In the url fairs/{year}/banquet/attendant/new one can create a new attendant.
4. In fairs/{year}/banquet/signup you can as a external person signup for the banquet. Your info will be saved when revisiting the signup. I will add compatability for those without kth and armada account further down the road. Right now this is what we need.