### PR TITLE
001 search desired roles

### DIFF
--- a/recruitment/forms.py
+++ b/recruitment/forms.py
@@ -54,8 +54,7 @@ class RecruitmentApplicationSearchForm(forms.Form):
 	)
 
 	priority = forms.ChoiceField(
-		# The choices will also be populated from the view, so this line might be superfluous
-		choices = [('', '-------'), (0, '1:st'), (1, '2:nd'), (2, '3:rd')],
+		# The choices will be populated from the view
 		widget=forms.Select(attrs={'class': 'form-control'}),
 		required=False
 	)

--- a/recruitment/forms.py
+++ b/recruitment/forms.py
@@ -14,52 +14,48 @@ from .models import RecruitmentPeriod, RecruitmentApplication, RoleApplication, 
 
 
 class RecruitmentPeriodForm(ModelForm):
-	class Meta:
-		model = RecruitmentPeriod
-		fields = '__all__'
-		exclude = ['image', 'interview_questions', 'application_questions', 'fair']
-		
-		widgets = {
-			'start_date': forms.TextInput(attrs={'class': 'datepicker'}),
-			'end_date': forms.TextInput(attrs={'class': 'datepicker'}),
-			'allowed_groups': forms.CheckboxSelectMultiple
-		}
-		
-		labels = {
-			'start_date': 'Start date (Format: 2016-12-24 13:37)',
-			'end_date': 'End date (Format: 2016-12-24 13:37)'
-		}
+    class Meta:
+        model = RecruitmentPeriod
+        fields = '__all__'
+        exclude = ['image', 'interview_questions', 'application_questions', 'fair']
+        
+        widgets = {
+            'start_date': forms.TextInput(attrs={'class': 'datepicker'}),
+            'end_date': forms.TextInput(attrs={'class': 'datepicker'}),
+            'allowed_groups': forms.CheckboxSelectMultiple
+        }
+        
+        labels = {
+            'start_date': 'Start date (Format: 2016-12-24 13:37)',
+            'end_date': 'End date (Format: 2016-12-24 13:37)'
+        }
 
 
 class CompareForm(forms.Form):
-	recruitment_periods = forms.ModelMultipleChoiceField(queryset = RecruitmentPeriod.objects.all(), widget = forms.CheckboxSelectMultiple(), required = True, label = 'Recruitment periods to compare')
-	include_late = forms.BooleanField(required = False, label = 'Include late applications, submitted after the end date')
+    recruitment_periods = forms.ModelMultipleChoiceField(queryset = RecruitmentPeriod.objects.all(), widget = forms.CheckboxSelectMultiple(), required = True, label = 'Recruitment periods to compare')
+    include_late = forms.BooleanField(required = False, label = 'Include late applications, submitted after the end date')
 
 
 class RecruitmentApplicationSearchForm(forms.Form):
     name = forms.CharField(widget=forms.TextInput(attrs={'class': 'form-control'}), required=False)
+
+    programme = forms.ModelChoiceField(
+        queryset=Programme.objects.all(),
+        widget=forms.Select(attrs={'class': 'form-control'}),
+        required=False
+    )
+
     submission_date = forms.CharField(widget=forms.TextInput(attrs={'class': 'form-control'}), required=False)
-    #roles = forms.CharField(widget=forms.TextInput(attrs={'class': 'form-control'}), required=False)
-    recommended_role = forms.ModelChoiceField(
+
+    role = forms.ModelChoiceField(
         queryset=Role.objects.all(),
         widget=forms.Select(attrs={'class': 'form-control'}),
         required=False
     )
 
     priority = forms.ChoiceField(
-        choices = [('', 'Any'), (0, 'First'), (1, 'Second'), (2, 'Third')],
-        widget=forms.Select(attrs={'class': 'form-control'}),
-        required=False
-    )
-
-    role = forms.ModelChoiceField(
-        queryset=Role.objects.all(), # Necessary?
-        widget=forms.Select(attrs={'class': 'form-control'}),
-        required=False
-    )
-
-    programme = forms.ModelChoiceField(
-        queryset=Programme.objects.all(),
+        # The choices will also be populated from the view, so this line might be superfluous
+        choices = [('', '-------'), (0, '1:st'), (1, '2:nd'), (2, '3:rd')],
         widget=forms.Select(attrs={'class': 'form-control'}),
         required=False
     )
@@ -69,12 +65,12 @@ class RecruitmentApplicationSearchForm(forms.Form):
         widget=forms.Select(attrs={'class': 'form-control'}),
         required=False
     )
-
-    # registration_year = forms.ChoiceField(
-    #     choices=[('', '-------')] + [(i, i) for i in range(2001, timezone.now().year + 1)],
-    #     widget=forms.Select(attrs={'class': 'form-control'}),
-    #     required=False
-    # )
+    
+    recommended_role = forms.ModelChoiceField(
+        queryset=Role.objects.all(),
+        widget=forms.Select(attrs={'class': 'form-control'}),
+        required=False
+    )
 
     rating = forms.ChoiceField(
         choices=[('', '-------'), (1, 1), (2, 2), (3, 3), (5, 5)],
@@ -83,7 +79,6 @@ class RecruitmentApplicationSearchForm(forms.Form):
     )
 
     state = forms.ChoiceField(
-
         widget=forms.Select(attrs={'class': 'form-control'}),
         required=False
     )
@@ -101,62 +96,41 @@ class RecruitmentApplicationSearchForm(forms.Form):
             application_list = [application for application in application_list if
                                 programme == application.user.profile.programme]
 
-        # registration_year = search_form.cleaned_data['registration_year']
-        # if registration_year:
-        #     application_list = [application for application in application_list if
-        #                         int(registration_year) == application.user.profile.registration_year]
-
-        rating = search_form.cleaned_data['rating']
-        if rating:
-            application_list = [application for application in application_list if int(rating) == application.rating]
-
         submission_date = search_form.cleaned_data['submission_date']
         if submission_date:
             application_list = [application for application in application_list if
                                 submission_date.lower() in date_filter(
                                     application.submission_date + timezone.timedelta(hours=2), "d M H:i").lower()]
 
-        # roles_string = search_form.cleaned_data['roles']
-        # if roles_string:
-        #     application_list = [application for application in application_list if
-        #                         roles_string.lower() in application.roles_string().lower()]
+        role = search_form.cleaned_data['role']
+        priority = (search_form.cleaned_data['priority']) # A string: 0, 1, or 2
 
+        # Three different search cases: role + priority, only role or only priority
+        if role and priority:
+            application_list = [application for application in application_list if (role, int(priority)) in [(roleapp.role, roleapp.order) for roleapp in application.roles]]
+        elif role:
+            application_list = [application for application in application_list if role in [roleapp.role for roleapp in application.roles]]
+        elif priority:
+            # Rare use case, matches all applications where any role has been chosen with the given priority
+            application_list = [application for application in application_list if int(priority) in [roleapp.order for roleapp in application.roles]]
+        
         interviewer = search_form.cleaned_data['interviewer']
         if interviewer:
             application_list = [application for application in application_list if
                                 interviewer == application.interviewer]
-
+        
         recommended_role = search_form.cleaned_data['recommended_role']
         if recommended_role:
             application_list = [application for application in application_list if
                                 recommended_role == application.recommended_role]
+        
+        rating = search_form.cleaned_data['rating']
+        if rating:
+            application_list = [application for application in application_list if int(rating) == application.rating]
 
         state = search_form.cleaned_data['state']
         if state:
             application_list = [application for application in application_list if state == application.state()]
-
-        # WIP
-        # Get role and priority
-        priority = (search_form.cleaned_data['priority']) # Django makes this a string even though it's declared an int in the form
-        role = search_form.cleaned_data['role']
-        # The user has chosen both a role and a priority,
-        # filter out the applications where an applicant
-        # has chosen exactly that role with that priority.
-        if role and priority:
-            print((role, priority))
-            print([[(roleapp.role, roleapp.order) for roleapp in application.roles] for application in application_list])
-            application_list = [application for application in application_list if (role, int(priority)) in [(roleapp.role, roleapp.order) for roleapp in application.roles]]
-        # The user has specified a role but not a 
-        # priority, filter out the applications
-        # that are for that role.
-        elif role:
-            application_list = [application for application in application_list if role in [roleapp.role for roleapp in application.roles]]
-        # The user has chosen a priority but no
-        # role... This is probably a rare use case.
-        # Filter out applications where any choice
-        # with the given priority has been made.
-        elif priority:
-            application_list = [application for application in application_list if int(priority) in [roleapp.order for roleapp in application.roles]]
 
         return application_list
 
@@ -171,62 +145,62 @@ class RolesForm(ModelForm):
         }
 
 def fix_phone_number(n):
-	if n is None: return None
-	
-	n = n.replace(' ', '')
-	n = n.replace('-', '')
-	
-	if n.startswith("00"): n = "+" + n[2:]
-	if n.startswith("0"): n = "+46" + n[1:]
-	
-	return n
+    if n is None: return None
+    
+    n = n.replace(' ', '')
+    n = n.replace('-', '')
+    
+    if n.startswith("00"): n = "+" + n[2:]
+    if n.startswith("0"): n = "+46" + n[1:]
+    
+    return n
 
 class ProfileForm(ModelForm):
-	def clean(self):
-		super(ProfileForm, self).clean()
-		
-		if 'phone_number' in self.cleaned_data:
-			self.cleaned_data['phone_number'] = fix_phone_number(self.cleaned_data['phone_number'])
-		
-		return self.cleaned_data
-	
-	def is_valid(self):
-		valid = super(ProfileForm, self).is_valid()
-		
-		if not valid: return valid
-		
-		phone_number = self.cleaned_data.get('phone_number')
-		
-		if phone_number is not None and not re.match(r'\+[0-9]+$', phone_number):
-			self.add_error('phone_number', 'Must only contain numbers and a leading plus.')
-			valid = False
-			
-		return valid
-	
-	def __init__(self, *args, **kwargs):
-		super(ProfileForm, self).__init__(*args, **kwargs)
-		
-		self.fields['registration_year'].required = True
-		self.fields['programme'].required = True
-		self.fields['phone_number'].required = True
-		self.fields['picture_original'].required = True
-		self.fields['preferred_language'].required = True
-	
-	class Meta:
-		model = Profile
-		fields = ['registration_year', 'programme', 'phone_number', 'linkedin_url', 'picture_original', 'preferred_language']
-		
-		labels = {
-			'linkedin_url': 'Link to your LinkedIn profile',
-			'picture_original': 'A picture of yourself',
-			'preferred_language': 'What language would you prefer to be interviewed in?'
-		}
-		
-		widgets = {
-			'registration_year': forms.Select(choices = [('', '--------')] + [(year, year) for year in range(2000, timezone.now().year + 1)], attrs = {'required': True}),
-			'programme': forms.Select(attrs={'required': True}),
-			'phone_number': forms.TextInput(attrs={'required': True})
-		}
+    def clean(self):
+        super(ProfileForm, self).clean()
+        
+        if 'phone_number' in self.cleaned_data:
+            self.cleaned_data['phone_number'] = fix_phone_number(self.cleaned_data['phone_number'])
+        
+        return self.cleaned_data
+    
+    def is_valid(self):
+        valid = super(ProfileForm, self).is_valid()
+        
+        if not valid: return valid
+        
+        phone_number = self.cleaned_data.get('phone_number')
+        
+        if phone_number is not None and not re.match(r'\+[0-9]+$', phone_number):
+            self.add_error('phone_number', 'Must only contain numbers and a leading plus.')
+            valid = False
+            
+        return valid
+    
+    def __init__(self, *args, **kwargs):
+        super(ProfileForm, self).__init__(*args, **kwargs)
+        
+        self.fields['registration_year'].required = True
+        self.fields['programme'].required = True
+        self.fields['phone_number'].required = True
+        self.fields['picture_original'].required = True
+        self.fields['preferred_language'].required = True
+    
+    class Meta:
+        model = Profile
+        fields = ['registration_year', 'programme', 'phone_number', 'linkedin_url', 'picture_original', 'preferred_language']
+        
+        labels = {
+            'linkedin_url': 'Link to your LinkedIn profile',
+            'picture_original': 'A picture of yourself',
+            'preferred_language': 'What language would you prefer to be interviewed in?'
+        }
+        
+        widgets = {
+            'registration_year': forms.Select(choices = [('', '--------')] + [(year, year) for year in range(2000, timezone.now().year + 1)], attrs = {'required': True}),
+            'programme': forms.Select(attrs={'required': True}),
+            'phone_number': forms.TextInput(attrs={'required': True})
+        }
 
 
 class RoleApplicationForm(forms.Form):

--- a/recruitment/forms.py
+++ b/recruitment/forms.py
@@ -14,208 +14,208 @@ from .models import RecruitmentPeriod, RecruitmentApplication, RoleApplication, 
 
 
 class RecruitmentPeriodForm(ModelForm):
-    class Meta:
-        model = RecruitmentPeriod
-        fields = '__all__'
-        exclude = ['image', 'interview_questions', 'application_questions', 'fair']
-        
-        widgets = {
-            'start_date': forms.TextInput(attrs={'class': 'datepicker'}),
-            'end_date': forms.TextInput(attrs={'class': 'datepicker'}),
-            'allowed_groups': forms.CheckboxSelectMultiple
-        }
-        
-        labels = {
-            'start_date': 'Start date (Format: 2016-12-24 13:37)',
-            'end_date': 'End date (Format: 2016-12-24 13:37)'
-        }
+	class Meta:
+		model = RecruitmentPeriod
+		fields = '__all__'
+		exclude = ['image', 'interview_questions', 'application_questions', 'fair']
+		
+		widgets = {
+			'start_date': forms.TextInput(attrs={'class': 'datepicker'}),
+			'end_date': forms.TextInput(attrs={'class': 'datepicker'}),
+			'allowed_groups': forms.CheckboxSelectMultiple
+		}
+		
+		labels = {
+			'start_date': 'Start date (Format: 2016-12-24 13:37)',
+			'end_date': 'End date (Format: 2016-12-24 13:37)'
+		}
 
 
 class CompareForm(forms.Form):
-    recruitment_periods = forms.ModelMultipleChoiceField(queryset = RecruitmentPeriod.objects.all(), widget = forms.CheckboxSelectMultiple(), required = True, label = 'Recruitment periods to compare')
-    include_late = forms.BooleanField(required = False, label = 'Include late applications, submitted after the end date')
+	recruitment_periods = forms.ModelMultipleChoiceField(queryset = RecruitmentPeriod.objects.all(), widget = forms.CheckboxSelectMultiple(), required = True, label = 'Recruitment periods to compare')
+	include_late = forms.BooleanField(required = False, label = 'Include late applications, submitted after the end date')
 
 
 class RecruitmentApplicationSearchForm(forms.Form):
-    name = forms.CharField(widget=forms.TextInput(attrs={'class': 'form-control'}), required=False)
+	name = forms.CharField(widget=forms.TextInput(attrs={'class': 'form-control'}), required=False)
 
-    programme = forms.ModelChoiceField(
-        queryset=Programme.objects.all(),
-        widget=forms.Select(attrs={'class': 'form-control'}),
-        required=False
-    )
+	programme = forms.ModelChoiceField(
+		queryset=Programme.objects.all(),
+		widget=forms.Select(attrs={'class': 'form-control'}),
+		required=False
+	)
 
-    submission_date = forms.CharField(widget=forms.TextInput(attrs={'class': 'form-control'}), required=False)
+	submission_date = forms.CharField(widget=forms.TextInput(attrs={'class': 'form-control'}), required=False)
 
-    role = forms.ModelChoiceField(
-        queryset=Role.objects.all(),
-        widget=forms.Select(attrs={'class': 'form-control'}),
-        required=False
-    )
+	role = forms.ModelChoiceField(
+		queryset=Role.objects.all(),
+		widget=forms.Select(attrs={'class': 'form-control'}),
+		required=False
+	)
 
-    priority = forms.ChoiceField(
-        # The choices will also be populated from the view, so this line might be superfluous
-        choices = [('', '-------'), (0, '1:st'), (1, '2:nd'), (2, '3:rd')],
-        widget=forms.Select(attrs={'class': 'form-control'}),
-        required=False
-    )
+	priority = forms.ChoiceField(
+		# The choices will also be populated from the view, so this line might be superfluous
+		choices = [('', '-------'), (0, '1:st'), (1, '2:nd'), (2, '3:rd')],
+		widget=forms.Select(attrs={'class': 'form-control'}),
+		required=False
+	)
 
-    interviewer = forms.ModelChoiceField(
-        queryset=User.objects.all(),
-        widget=forms.Select(attrs={'class': 'form-control'}),
-        required=False
-    )
-    
-    recommended_role = forms.ModelChoiceField(
-        queryset=Role.objects.all(),
-        widget=forms.Select(attrs={'class': 'form-control'}),
-        required=False
-    )
+	interviewer = forms.ModelChoiceField(
+		queryset=User.objects.all(),
+		widget=forms.Select(attrs={'class': 'form-control'}),
+		required=False
+	)
+	
+	recommended_role = forms.ModelChoiceField(
+		queryset=Role.objects.all(),
+		widget=forms.Select(attrs={'class': 'form-control'}),
+		required=False
+	)
 
-    rating = forms.ChoiceField(
-        choices=[('', '-------'), (1, 1), (2, 2), (3, 3), (5, 5)],
-        widget=forms.Select(attrs={'class': 'form-control'}),
-        required=False
-    )
+	rating = forms.ChoiceField(
+		choices=[('', '-------'), (1, 1), (2, 2), (3, 3), (5, 5)],
+		widget=forms.Select(attrs={'class': 'form-control'}),
+		required=False
+	)
 
-    state = forms.ChoiceField(
-        widget=forms.Select(attrs={'class': 'form-control'}),
-        required=False
-    )
+	state = forms.ChoiceField(
+		widget=forms.Select(attrs={'class': 'form-control'}),
+		required=False
+	)
 
-    def applications_matching_search(self, application_list):
-        search_form = self
+	def applications_matching_search(self, application_list):
+		search_form = self
 
-        name = search_form.cleaned_data['name']
-        if name:
-            application_list = [application for application in application_list if
-                                name.lower() in application.user.get_full_name().lower()]
+		name = search_form.cleaned_data['name']
+		if name:
+			application_list = [application for application in application_list if
+								name.lower() in application.user.get_full_name().lower()]
 
-        programme = search_form.cleaned_data['programme']
-        if programme:
-            application_list = [application for application in application_list if
-                                programme == application.user.profile.programme]
+		programme = search_form.cleaned_data['programme']
+		if programme:
+			application_list = [application for application in application_list if
+								programme == application.user.profile.programme]
 
-        submission_date = search_form.cleaned_data['submission_date']
-        if submission_date:
-            application_list = [application for application in application_list if
-                                submission_date.lower() in date_filter(
-                                    application.submission_date + timezone.timedelta(hours=2), "d M H:i").lower()]
+		submission_date = search_form.cleaned_data['submission_date']
+		if submission_date:
+			application_list = [application for application in application_list if
+								submission_date.lower() in date_filter(
+									application.submission_date + timezone.timedelta(hours=2), "d M H:i").lower()]
 
-        role = search_form.cleaned_data['role']
-        priority = (search_form.cleaned_data['priority']) # A string: 0, 1, or 2
+		role = search_form.cleaned_data['role']
+		priority = (search_form.cleaned_data['priority']) # A string: 0, 1, or 2
 
-        # Three different search cases: role + priority, only role or only priority
-        if role and priority:
-            application_list = [application for application in application_list if (role, int(priority)) in [(roleapp.role, roleapp.order) for roleapp in application.roles]]
-        elif role:
-            application_list = [application for application in application_list if role in [roleapp.role for roleapp in application.roles]]
-        elif priority:
-            # Rare use case, matches all applications where any role has been chosen with the given priority
-            application_list = [application for application in application_list if int(priority) in [roleapp.order for roleapp in application.roles]]
-        
-        interviewer = search_form.cleaned_data['interviewer']
-        if interviewer:
-            application_list = [application for application in application_list if
-                                interviewer == application.interviewer]
-        
-        recommended_role = search_form.cleaned_data['recommended_role']
-        if recommended_role:
-            application_list = [application for application in application_list if
-                                recommended_role == application.recommended_role]
-        
-        rating = search_form.cleaned_data['rating']
-        if rating:
-            application_list = [application for application in application_list if int(rating) == application.rating]
+		# Three different search cases: role + priority, only role or only priority
+		if role and priority:
+			application_list = [application for application in application_list if (role, int(priority)) in [(roleapp.role, roleapp.order) for roleapp in application.roles]]
+		elif role:
+			application_list = [application for application in application_list if role in [roleapp.role for roleapp in application.roles]]
+		elif priority:
+			# Rare use case, matches all applications where any role has been chosen with the given priority
+			application_list = [application for application in application_list if int(priority) in [roleapp.order for roleapp in application.roles]]
+		
+		interviewer = search_form.cleaned_data['interviewer']
+		if interviewer:
+			application_list = [application for application in application_list if
+								interviewer == application.interviewer]
+		
+		recommended_role = search_form.cleaned_data['recommended_role']
+		if recommended_role:
+			application_list = [application for application in application_list if
+								recommended_role == application.recommended_role]
+		
+		rating = search_form.cleaned_data['rating']
+		if rating:
+			application_list = [application for application in application_list if int(rating) == application.rating]
 
-        state = search_form.cleaned_data['state']
-        if state:
-            application_list = [application for application in application_list if state == application.state()]
+		state = search_form.cleaned_data['state']
+		if state:
+			application_list = [application for application in application_list if state == application.state()]
 
-        return application_list
+		return application_list
 
 class RolesForm(ModelForm):
-    class Meta:
-        model = Role
+	class Meta:
+		model = Role
 
-        exclude = ('group',)
-        widgets = {
-            'permissions': forms.CheckboxSelectMultiple(),
-            'description': forms.Textarea(),
-        }
+		exclude = ('group',)
+		widgets = {
+			'permissions': forms.CheckboxSelectMultiple(),
+			'description': forms.Textarea(),
+		}
 
 def fix_phone_number(n):
-    if n is None: return None
-    
-    n = n.replace(' ', '')
-    n = n.replace('-', '')
-    
-    if n.startswith("00"): n = "+" + n[2:]
-    if n.startswith("0"): n = "+46" + n[1:]
-    
-    return n
+	if n is None: return None
+	
+	n = n.replace(' ', '')
+	n = n.replace('-', '')
+	
+	if n.startswith("00"): n = "+" + n[2:]
+	if n.startswith("0"): n = "+46" + n[1:]
+	
+	return n
 
 class ProfileForm(ModelForm):
-    def clean(self):
-        super(ProfileForm, self).clean()
-        
-        if 'phone_number' in self.cleaned_data:
-            self.cleaned_data['phone_number'] = fix_phone_number(self.cleaned_data['phone_number'])
-        
-        return self.cleaned_data
-    
-    def is_valid(self):
-        valid = super(ProfileForm, self).is_valid()
-        
-        if not valid: return valid
-        
-        phone_number = self.cleaned_data.get('phone_number')
-        
-        if phone_number is not None and not re.match(r'\+[0-9]+$', phone_number):
-            self.add_error('phone_number', 'Must only contain numbers and a leading plus.')
-            valid = False
-            
-        return valid
-    
-    def __init__(self, *args, **kwargs):
-        super(ProfileForm, self).__init__(*args, **kwargs)
-        
-        self.fields['registration_year'].required = True
-        self.fields['programme'].required = True
-        self.fields['phone_number'].required = True
-        self.fields['picture_original'].required = True
-        self.fields['preferred_language'].required = True
-    
-    class Meta:
-        model = Profile
-        fields = ['registration_year', 'programme', 'phone_number', 'linkedin_url', 'picture_original', 'preferred_language']
-        
-        labels = {
-            'linkedin_url': 'Link to your LinkedIn profile',
-            'picture_original': 'A picture of yourself',
-            'preferred_language': 'What language would you prefer to be interviewed in?'
-        }
-        
-        widgets = {
-            'registration_year': forms.Select(choices = [('', '--------')] + [(year, year) for year in range(2000, timezone.now().year + 1)], attrs = {'required': True}),
-            'programme': forms.Select(attrs={'required': True}),
-            'phone_number': forms.TextInput(attrs={'required': True})
-        }
+	def clean(self):
+		super(ProfileForm, self).clean()
+		
+		if 'phone_number' in self.cleaned_data:
+			self.cleaned_data['phone_number'] = fix_phone_number(self.cleaned_data['phone_number'])
+		
+		return self.cleaned_data
+	
+	def is_valid(self):
+		valid = super(ProfileForm, self).is_valid()
+		
+		if not valid: return valid
+		
+		phone_number = self.cleaned_data.get('phone_number')
+		
+		if phone_number is not None and not re.match(r'\+[0-9]+$', phone_number):
+			self.add_error('phone_number', 'Must only contain numbers and a leading plus.')
+			valid = False
+			
+		return valid
+	
+	def __init__(self, *args, **kwargs):
+		super(ProfileForm, self).__init__(*args, **kwargs)
+		
+		self.fields['registration_year'].required = True
+		self.fields['programme'].required = True
+		self.fields['phone_number'].required = True
+		self.fields['picture_original'].required = True
+		self.fields['preferred_language'].required = True
+	
+	class Meta:
+		model = Profile
+		fields = ['registration_year', 'programme', 'phone_number', 'linkedin_url', 'picture_original', 'preferred_language']
+		
+		labels = {
+			'linkedin_url': 'Link to your LinkedIn profile',
+			'picture_original': 'A picture of yourself',
+			'preferred_language': 'What language would you prefer to be interviewed in?'
+		}
+		
+		widgets = {
+			'registration_year': forms.Select(choices = [('', '--------')] + [(year, year) for year in range(2000, timezone.now().year + 1)], attrs = {'required': True}),
+			'programme': forms.Select(attrs={'required': True}),
+			'phone_number': forms.TextInput(attrs={'required': True})
+		}
 
 
 class RoleApplicationForm(forms.Form):
-    role1 = forms.ModelChoiceField(label='Role 1', queryset=Role.objects.none(), widget=forms.Select(attrs={'required': True}))
-    role2 = forms.ModelChoiceField(label='Role 2', queryset=Role.objects.none(), required=False)
-    role3 = forms.ModelChoiceField(label='Role 3', queryset=Role.objects.none(), required=False)
+	role1 = forms.ModelChoiceField(label='Role 1', queryset=Role.objects.none(), widget=forms.Select(attrs={'required': True}))
+	role2 = forms.ModelChoiceField(label='Role 2', queryset=Role.objects.none(), required=False)
+	role3 = forms.ModelChoiceField(label='Role 3', queryset=Role.objects.none(), required=False)
 
 
 class ProfilePictureForm(ModelForm):
-    '''
-    Simple 1-field form for changing profile picture in interview form
-    '''
-    class Meta:
-        model = Profile
-        fields = ('picture_original',)
-        labels = {
-            'picture_original': 'Profile picture',
-        }
+	'''
+	Simple 1-field form for changing profile picture in interview form
+	'''
+	class Meta:
+		model = Profile
+		fields = ('picture_original',)
+		labels = {
+			'picture_original': 'Profile picture',
+		}

--- a/recruitment/models.py
+++ b/recruitment/models.py
@@ -320,7 +320,6 @@ class RecruitmentApplication(models.Model):
 		else:
 			return 'new'
 
-
 	def roles_string(self):
 		return ' '.join(['(%s) %s' % (role.role.organization_group, role.role.name) for role in self.roleapplication_set.order_by('order')])
 

--- a/recruitment/views.py
+++ b/recruitment/views.py
@@ -411,8 +411,6 @@ def recruitment_period(request, year, pk, template_name='recruitment/recruitment
 	# user should be forbidden to look at applications that are not below them in hierari
 	#application_list = list(filter(lambda application: eligible_to_see_application(application, user), application_list))
 
-
-
 	search_form = RecruitmentApplicationSearchForm(request.GET or None)
 	search_form.fields['interviewer'].choices = [('', '---------')] + [(interviewer.pk, interviewer.get_full_name()) for
 																		interviewer in recruitment_period.interviewers()]
@@ -453,7 +451,7 @@ def recruitment_period(request, year, pk, template_name='recruitment/recruitment
 		SearchField('Name', 'user__last_name'),
 		SearchField('Programme', 'user__profile__programme'),
 		SearchField('Submitted', 'submission_date'),
-		SearchField('Role', 'role'),
+		SearchField('Role', None),
 		SearchField('Priority', None),
 		SearchField('Interviewer', 'interviewer__last_name'),
 		SearchField('Recommended role', 'recommended_role'),

--- a/recruitment/views.py
+++ b/recruitment/views.py
@@ -401,8 +401,6 @@ def recruitment_period(request, year, pk, template_name='recruitment/recruitment
 	# but in case something goes awry.
 	if eligible_roles < 1:
 		eligible_roles = 1
-	elif eligible_roles > 3:
-		eligible_roles = 3 
 
 	fair = get_object_or_404(Fair, year=year)
 	start = time.time()

--- a/recruitment/views.py
+++ b/recruitment/views.py
@@ -408,7 +408,6 @@ def recruitment_period(request, year, pk, template_name='recruitment/recruitment
 	order_by_query = ('' if sort_ascending else '-') + sort_field
 
 	application_list = recruitment_period.recruitmentapplication_set.order_by(order_by_query, '-submission_date').all().prefetch_related('roleapplication_set')
-
 	# user should be forbidden to look at applications that are not below them in hierari
 	#application_list = list(filter(lambda application: eligible_to_see_application(application, user), application_list))
 
@@ -420,6 +419,10 @@ def recruitment_period(request, year, pk, template_name='recruitment/recruitment
 	search_form.fields['state'].choices = [('', '-------')] + recruitment_period.state_choices()
 	search_form.fields['recommended_role'].choices = [('', '---------')] + [(role.pk, role.name) for
 																		role in recruitment_period.recruitable_roles.all()]
+
+	search_form.fields['role'].choices = [('', '-------')] + [(role.pk, role.name) for role in recruitment_period.recruitable_roles.all()]
+
+	search_form.fields['priority'].choices = [('', 'Any')] + [(str(i), str(i+1)) for i in range(recruitment_period.eligible_roles)]
 
 	if search_form.is_valid():
 		application_list = search_form.applications_matching_search(application_list)
@@ -449,13 +452,13 @@ def recruitment_period(request, year, pk, template_name='recruitment/recruitment
 	search_fields = [
 		SearchField('Name', 'user__last_name'),
 		SearchField('Programme', 'user__profile__programme'),
-		SearchField('Registration year', 'user__profile__registration_year'),
-		SearchField('Rating', 'rating'),
 		SearchField('Submitted', 'submission_date'),
-		SearchField('Roles', None),
-		SearchField('Recommended role', 'recommended_role'),
+		SearchField('Role', 'role'),
+		SearchField('Priority', None),
 		SearchField('Interviewer', 'interviewer__last_name'),
-		SearchField('State', None),
+		SearchField('Recommended role', 'recommended_role'),
+		SearchField('Rating', 'rating'),
+		SearchField('State', None)
 	]
 
 	profile = Profile.objects.filter(user = request.user).first()

--- a/recruitment/views.py
+++ b/recruitment/views.py
@@ -427,9 +427,6 @@ def recruitment_period(request, year, pk, template_name='recruitment/recruitment
 	search_form.fields['recommended_role'].choices = [('', '---------')] + [(role.pk, role.name) for
 																		role in recruitment_period.recruitable_roles.all()]
 	search_form.fields['state'].choices = [('', '-------')] + recruitment_period.state_choices()
-	
-
-	
 
 	if search_form.is_valid():
 		application_list = search_form.applications_matching_search(application_list)

--- a/templates/recruitment/recruitment_application_table.html
+++ b/templates/recruitment/recruitment_application_table.html
@@ -46,13 +46,13 @@
                 </div>
 
             </td>
-            <td>{{ search_form.programme }}</td>
-            <td>{{ search_form.registration_year }}</td>
-            <td>{{ search_form.rating }}</td>
-            <td>{{ search_form.submission_date }}</td>
-            <td>{{ search_form.roles }}</td>
+			<td>{{ search_form.programme }}</td>
+			<td>{{ search_form.submission_date }}</td>
+            <td>{{ search_form.role }}<br></td>
+			<td>{{ search_form.priority }}<br></td>
+			<td>{{ search_form.interviewer }}</td>
             <td>{{ search_form.recommended_role }}</td>
-            <td>{{ search_form.interviewer }}</td>
+			<td>{{ search_form.rating }}</td>
             <td>{{ search_form.state }}<br></td>
         </form>
     </tr>
@@ -70,20 +70,18 @@
 				{% if application.user.profile.programme.shortening %} {{ application.user.profile.programme.shortening }}
 				{% else %} {{ application.user.profile.programme }} {% endif %}
 			</td>
-            <td>{{ application.user.profile.registration_year }}</td>
-            <td>{% if application.rating != None %}{{ application.rating }}{% endif %}</td>
+			{%comment%}<td>{{ application.user.profile.registration_year }}</td>{%endcomment%}
+			<td>{{ application.submission_date|date:"d M H:i" }}</td>
 
-
-            <td>{{ application.submission_date|date:"d M H:i" }}</td>
-            <td>
+			<td colspan="2">
 				<ol style="margin: 0; padding: 0 0 0 20px;">
 					{% for role in application.roles %}
 						<li>{{ role.role.name }}</li>
 					{% endfor %}
 				</ol>
             </td>
-            <td>{{ application.recommended_role.name }}</td>
-            <td>
+			
+			<td>
                 {% if application.interviewer %}
                     {{ application.interviewer.get_full_name }}
                 {% endif %}
@@ -91,7 +89,11 @@
                 {% if application.interviewer2 %}
                     <br />{{ application.interviewer2.get_full_name }}
                 {% endif %}
-            </td>
+			</td>
+			
+            <td>{{ application.recommended_role.name }}</td>
+			
+			<td>{% if application.rating != None %}{{ application.rating }}{% endif %}</td>
 
             <td>
                 {% if application.state == 'accepted' %}

--- a/templates/recruitment/recruitment_application_table.html
+++ b/templates/recruitment/recruitment_application_table.html
@@ -1,72 +1,72 @@
 <div class="table-responsive">
 <table class="table">
-    <thead>
-    <tr>
+	<thead>
+	<tr>
 
-        {% for search_field in search_fields %}
-            <th>
-            {% if search_field.model_field_name %}
-                <form class="search-form">
-                    <input type="hidden" name="sort_field" value="{{ search_field.model_field_name }}">
-                    {% if request.GET.sort_field == search_field.model_field_name and request.GET.sort_ascending == 'true' %}
-                        <input type="hidden" name="sort_ascending" value="false">
-                    {% else %}
-                        <input type="hidden" name="sort_ascending" value="true">
-                    {% endif %}
-                    <input type="hidden" name="scroll_y" class="scroll_y" value="0">
-                    <button class="btn btn-link">{{ search_field.name }}
-                        {% if request.GET.sort_field == search_field.model_field_name %}
-                            {% if request.GET.sort_ascending == 'true' %}↑{% else %}↓{% endif %}
-                        {% endif %}
-                    </button>
-                </form>
-            {% else %}
-                <button class="btn btn-link" disabled>
-                {{ search_field.name }}
-                </button>
-            {% endif %}
+		{% for search_field in search_fields %}
+			<th>
+			{% if search_field.model_field_name %}
+				<form class="search-form">
+					<input type="hidden" name="sort_field" value="{{ search_field.model_field_name }}">
+					{% if request.GET.sort_field == search_field.model_field_name and request.GET.sort_ascending == 'true' %}
+						<input type="hidden" name="sort_ascending" value="false">
+					{% else %}
+						<input type="hidden" name="sort_ascending" value="true">
+					{% endif %}
+					<input type="hidden" name="scroll_y" class="scroll_y" value="0">
+					<button class="btn btn-link">{{ search_field.name }}
+						{% if request.GET.sort_field == search_field.model_field_name %}
+							{% if request.GET.sort_ascending == 'true' %}↑{% else %}↓{% endif %}
+						{% endif %}
+					</button>
+				</form>
+			{% else %}
+				<button class="btn btn-link" disabled>
+				{{ search_field.name }}
+				</button>
+			{% endif %}
 
-            </th>
-        {% endfor %}
+			</th>
+		{% endfor %}
 
-    </tr>
-    {% if show_search_bar %}
-    <tr>
-        <form class="search-form">
-            <input type="hidden" name="scroll_y" class="scroll_y" value="0">
-            <input type="hidden" name="sort_field" value="{{ request.GET.sort_field }}">
-            <input type="hidden" name="sort_ascending" value="{{ request.GET.sort_ascending }}">
-            <td>{{ search_form.name }}
-                <br>
+	</tr>
+	{% if show_search_bar %}
+	<tr>
+		<form class="search-form">
+			<input type="hidden" name="scroll_y" class="scroll_y" value="0">
+			<input type="hidden" name="sort_field" value="{{ request.GET.sort_field }}">
+			<input type="hidden" name="sort_ascending" value="{{ request.GET.sort_ascending }}">
+			<td>{{ search_form.name }}
+				<br>
 
 
-                        <div class="btn-group">
-                    <button class="btn btn-primary" type="submit"><span class="glyphicon glyphicon-search"></span> Search</button>
+						<div class="btn-group">
+					<button class="btn btn-primary" type="submit"><span class="glyphicon glyphicon-search"></span> Search</button>
 
-                </div>
+				</div>
 
-            </td>
+			</td>
 			<td>{{ search_form.programme }}</td>
 			<td>{{ search_form.submission_date }}</td>
-            <td>{{ search_form.role }}<br></td>
+			<td>{{ search_form.role }}<br></td>
 			<td>{{ search_form.priority }}<br></td>
 			<td>{{ search_form.interviewer }}</td>
-            <td>{{ search_form.recommended_role }}</td>
+			<td>{{ search_form.recommended_role }}</td>
 			<td>{{ search_form.rating }}</td>
-            <td>{{ search_form.state }}<br></td>
-        </form>
-    </tr>
-    {% endif %}
-    </thead>
-    {% for application in applications %}
-        <tr>
-            <td>
-                <a href="{% url 'recruitment_application_interview' fair.year recruitment_period.id application.id %}">
-                    {% include 'recruitment/user_name.html' with user=application.user %}
-                </a>
-            </td>
+			<td>{{ search_form.state }}<br></td>
+		</form>
+	</tr>
+	{% endif %}
+	</thead>
+	{% for application in applications %}
+		<tr>
+			<td>
+				<a href="{% url 'recruitment_application_interview' fair.year recruitment_period.id application.id %}">
+					{% include 'recruitment/user_name.html' with user=application.user %}
+				</a>
+			</td>
 
-            <td>
+			<td>
 				{% if application.user.profile.programme.shortening %} {{ application.user.profile.programme.shortening }}
 				{% else %} {{ application.user.profile.programme }} {% endif %}
 			</td>
@@ -79,42 +79,42 @@
 						<li>{{ role.role.name }}</li>
 					{% endfor %}
 				</ol>
-            </td>
-			
-			<td>
-                {% if application.interviewer %}
-                    {{ application.interviewer.get_full_name }}
-                {% endif %}
-                
-                {% if application.interviewer2 %}
-                    <br />{{ application.interviewer2.get_full_name }}
-                {% endif %}
 			</td>
 			
-            <td>{{ application.recommended_role.name }}</td>
+			<td>
+				{% if application.interviewer %}
+					{{ application.interviewer.get_full_name }}
+				{% endif %}
+				
+				{% if application.interviewer2 %}
+					<br />{{ application.interviewer2.get_full_name }}
+				{% endif %}
+			</td>
+			
+			<td>{{ application.recommended_role.name }}</td>
 			
 			<td>{% if application.rating != None %}{{ application.rating }}{% endif %}</td>
 
-            <td>
-                {% if application.state == 'accepted' %}
-                    <span class="label label-success">{{ application.status.capitalize }}</span>
-                {% elif application.state == 'rejected' or application.state == 'withdrawn' %}
-                    <span class="label label-danger">{{ application.status.capitalize }}</span>
-                {% elif application.state == 'new' %}
-                    <span class="label label-default">New</span>
-                {% elif application.state == 'interview_delegated' %}
-                    <span class="label label-warning">Delegated</span>
-                {% elif application.state == 'interview_planned' %}
-                    <span class="label label-info">Planned</span>
-                {% elif application.state == 'interview_done' %}
-                    <span class="label label-primary">Done</span>
-                    {% else %}
-                    {{ application.state }}
-                {% endif %}
-            </td>
+			<td>
+				{% if application.state == 'accepted' %}
+					<span class="label label-success">{{ application.status.capitalize }}</span>
+				{% elif application.state == 'rejected' or application.state == 'withdrawn' %}
+					<span class="label label-danger">{{ application.status.capitalize }}</span>
+				{% elif application.state == 'new' %}
+					<span class="label label-default">New</span>
+				{% elif application.state == 'interview_delegated' %}
+					<span class="label label-warning">Delegated</span>
+				{% elif application.state == 'interview_planned' %}
+					<span class="label label-info">Planned</span>
+				{% elif application.state == 'interview_done' %}
+					<span class="label label-primary">Done</span>
+					{% else %}
+					{{ application.state }}
+				{% endif %}
+			</td>
 
-        </tr>
-    {% endfor %}
+		</tr>
+	{% endfor %}
 </table>
 </div>
 


### PR DESCRIPTION
Removed registration year and role column in favor of two new ones: role & priority. 

![Applications_table_header](https://user-images.githubusercontent.com/17951798/58009739-5f878480-7aef-11e9-8176-165f86c1b117.png)

The new role column contains every role that can be applied for in the given recruitment period.
The new priority column contains '1:st', '2:nd', '3:rd', ... corresponding to the priority the applicant has given for each role. It is decided by the eligible_roles attribute in the recruitment period, but capped at 3 (and will be set to 1 if eligible_roles < 1). 

If both role and priority are selected, the application table will only display the applications of people who have applied for the given role with that priority, but still display all the roles that person has applied for. For instance, searching for 'Head of IT' with priority '2:nd' in the project group recruitment looks like this:

![head_of_it_2nd](https://user-images.githubusercontent.com/17951798/58009850-93fb4080-7aef-11e9-8250-c630f7e051e1.png)

In the (weird) use case of searching for a priority only, the application table will display all applications where a choice has been given for that priority. This means searching for priority '3rd' will display all applications where a 3rd choice has been given, i.e. filtering out applications where only 1st and 2nd choices are given. It looks like this:

![3rd_prio_only](https://user-images.githubusercontent.com/17951798/58010153-226fc200-7af0-11e9-88f1-03a2732263d2.png)

As is visible from the picture above, the column beneath role and priority is now a double-wide column that displays the roles in order of the applicant's preference (as it was before).

**Apologies for making a mess of the indentation.**