### PR TITLE
017 crm statistics

### DIFF
--- a/companies/views.py
+++ b/companies/views.py
@@ -123,6 +123,7 @@ def is_equal(q1, q2):
 @permission_required('companies.base')
 def statistics(request, year):
 	fair = get_object_or_404(Fair, year = year)
+	current_fair_groups = Group.objects.filter(fair = fair)
 
 	form = StatisticsForm(request.POST or None)
 
@@ -137,7 +138,12 @@ def statistics(request, year):
 		rows = 0
 
 		for signature in signatures_raw:
-			responsibilities = list(CompanyCustomerResponsible.objects.filter(company = signature.company))
+			all_responsibilities = list(CompanyCustomerResponsible.objects.filter(company = signature.company))
+			# loop to exclude previous years' responsibilities
+			responsibilities = []
+			for responsibility in all_responsibilities:
+				if responsibility.group in current_fair_groups:
+					responsibilities.append(responsibility)
 
 			if smallest is None or signature.timestamp < smallest:
 				smallest = signature.timestamp

--- a/templates/companies/statistics.html
+++ b/templates/companies/statistics.html
@@ -23,7 +23,7 @@
 				<th>Signatures</th>
 			</tr>
 		</thead>
-		
+
 		{% for contract in contracts %}
 			{% if contract.signatures %}
 				{% for signature in contract.signatures %}
@@ -67,9 +67,11 @@
 <p>Click on a person's name to traice their progress.</p>
 
 {% for contract in contracts %}
-	<hr />
-	<h3>{{ contract.name }}</h3>
-	<div id="chart_div_{{ contract.i }}" style="margin-top: -30px; width: 100%;"></div>
+	{% if contract.signatures %}
+		<hr />
+		<h3>{{ contract.name }}</h3>
+		<div id="chart_div_{{ contract.i }}" style="margin-top: -30px; width: 100%;"></div>
+	{% endif %}
 {% endfor %}
 {% endblock %}
 
@@ -89,27 +91,27 @@
 	<script>
 		google.charts.load('current', {'packages':['corechart']});
 		google.charts.setOnLoadCallback(drawChart);
-		
+
 		function drawChart()
 		{
 			var data = new google.visualization.DataTable();
-			
+
 			data.addColumn('datetime', 'Number of signatures');
-			
+
 			{% for signature in contract.signatures %}
 				data.addColumn('number', '{% if signature.responsibilities %} {% for responsibility in signature.responsibilities %}{% if responsibility.group.allow_statistics %}{{ responsibility.group }} – {{ responsibility.users.all | join:", " }}{% endif %}{% endfor %}{% else %}no responsibilities{% endif %}');
 			{% endfor %}
-			
+
 			data.addRows([
 			{% for row in contract.table %}
 				[
 					new Date({{ row.timestamp|date:'Y' }}, {{ row.timestamp|date:'m'|add:"-1" }}, {{ row.timestamp|date:'d' }}, {{ row.timestamp|date:'H' }}, {{ row.timestamp|date:'i' }}, {{ row.timestamp|date:'s' }})
-					
+
 					{% for cell in row.cells %}
 						, {% if cell %} {{ cell }} {% else %} null {% endif %}
 					{% endfor %}
 					],
-				
+
 			{% endfor %}
 			]);
 
@@ -140,10 +142,10 @@
 					title: "Time"
 				}
 			};
-			
+
 			var chart = new google.visualization.LineChart(
 			document.getElementById('chart_div_{{ contract.i }}'));
-			
+
 			chart.draw(data, options);
 		}
 	</script>


### PR DESCRIPTION
The statistics page of the CRM system was showing previous year's responsibles. Responsibiliites are not year specific but the group that is connected to the responsibility is - therefore only responsibles connected to a group for the current fair are now added to the list of responsibilitites.

Also fixed so that contracts that do not have any signatures don't show an empty graph but are hidden.