### PR TITLE
057 update catalogue forms

### DIFF
--- a/exhibitors/admin.py
+++ b/exhibitors/admin.py
@@ -15,31 +15,26 @@ class ExhibitorAdmin(admin.ModelAdmin):
 class CatalogueIndustryAdmin(admin.ModelAdmin):
 	list_display = ('industry', 'include_in_form')
 	list_filter = ['include_in_form']
-	ordering = ['industry']
 
 @admin.register(CatalogueValue)
 class CatalogueValueAdmin(admin.ModelAdmin):
 	list_display = ('value', 'include_in_form')
 	list_filter = ['include_in_form']
-	ordering = ['value']
 
 @admin.register(CatalogueEmployment)
 class CatalogueEmploymentAdmin(admin.ModelAdmin):
 	list_display = ('employment', 'include_in_form')
 	list_filter = ['include_in_form']
-	ordering = ['employment']
 
 @admin.register(CatalogueLocation)
 class CatalogueLocationAdmin(admin.ModelAdmin):
 	list_display = ('location', 'include_in_form')
 	list_filter = ['include_in_form']
-	ordering = ['location']
 
 @admin.register(CatalogueBenefit)
 class CatalogueBenefitAdmin(admin.ModelAdmin):
 	list_display = ('benefit', 'include_in_form')
 	list_filter = ['include_in_form']
-	ordering = ['benefit']
 
 admin.site.register(Location)
 admin.site.register(Booth)

--- a/exhibitors/admin.py
+++ b/exhibitors/admin.py
@@ -11,12 +11,36 @@ class ExhibitorAdmin(admin.ModelAdmin):
 	ordering = ['-fair__year', 'company']
 	list_filter = ['fair']
 
+@admin.register(CatalogueIndustry)
+class CatalogueIndustryAdmin(admin.ModelAdmin):
+	list_display = ('industry', 'include_in_form')
+	list_filter = ['include_in_form']
+	ordering = ['industry']
 
-admin.site.register(CatalogueIndustry)
-admin.site.register(CatalogueValue)
-admin.site.register(CatalogueEmployment)
-admin.site.register(CatalogueLocation)
-admin.site.register(CatalogueBenefit)
+@admin.register(CatalogueValue)
+class CatalogueValueAdmin(admin.ModelAdmin):
+	list_display = ('value', 'include_in_form')
+	list_filter = ['include_in_form']
+	ordering = ['value']
+
+@admin.register(CatalogueEmployment)
+class CatalogueEmploymentAdmin(admin.ModelAdmin):
+	list_display = ('employment', 'include_in_form')
+	list_filter = ['include_in_form']
+	ordering = ['employment']
+
+@admin.register(CatalogueLocation)
+class CatalogueLocationAdmin(admin.ModelAdmin):
+	list_display = ('location', 'include_in_form')
+	list_filter = ['include_in_form']
+	ordering = ['location']
+
+@admin.register(CatalogueBenefit)
+class CatalogueBenefitAdmin(admin.ModelAdmin):
+	list_display = ('benefit', 'include_in_form')
+	list_filter = ['include_in_form']
+	ordering = ['benefit']
+
 admin.site.register(Location)
 admin.site.register(Booth)
 admin.site.register(ExhibitorInBooth)

--- a/exhibitors/models.py
+++ b/exhibitors/models.py
@@ -20,7 +20,9 @@ class CatalogueIndustry(models.Model):
     include_in_form = models.BooleanField(default = True)
     include_in_form.help_text = "The alternative is only visible in forms if this attribute is checked."
     def __str__(self): return self.industry
-    class Meta: default_permissions = []
+    class Meta:
+        default_permissions = []
+        ordering = ['industry']
 
 
 class CatalogueValue(models.Model):
@@ -28,7 +30,9 @@ class CatalogueValue(models.Model):
     include_in_form = models.BooleanField(default = True)
     include_in_form.help_text = "The alternative is only visible in forms if this attribute is checked."
     def __str__(self): return self.value
-    class Meta: default_permissions = []
+    class Meta:
+        default_permissions = []
+        ordering = ['value']
 
 
 class CatalogueEmployment(models.Model):
@@ -36,7 +40,9 @@ class CatalogueEmployment(models.Model):
     include_in_form = models.BooleanField(default = True)
     include_in_form.help_text = "The alternative is only visible in forms if this attribute is checked."
     def __str__(self): return self.employment
-    class Meta: default_permissions = []
+    class Meta:
+        default_permissions = []
+        ordering = ['employment']
 
 
 class CatalogueLocation(models.Model):
@@ -44,14 +50,18 @@ class CatalogueLocation(models.Model):
     include_in_form = models.BooleanField(default = True)
     include_in_form.help_text = "The alternative is only visible in forms if this attribute is checked."
     def __str__(self): return self.location
-    class Meta: default_permissions = []
+    class Meta:
+        default_permissions = []
+        ordering = ['location']
 
 class CatalogueBenefit(models.Model):
     benefit = models.CharField(blank = False, max_length = 255)
     include_in_form = models.BooleanField(default = True)
     include_in_form.help_text = "The alternative is only visible in forms if this attribute is checked."
     def __str__(self): return self.benefit
-    class Meta: default_permissions = []
+    class Meta:
+        default_permissions = []
+        ordering = ['benefit']
 
 
 # A company (or organisation) participating in a fair

--- a/register/forms.py
+++ b/register/forms.py
@@ -8,7 +8,7 @@ from django.contrib.auth.forms import UserCreationForm, AuthenticationForm, Pass
 from django.contrib.auth.models import User
 
 from companies.models import Group, Company
-from exhibitors.models import Exhibitor
+from exhibitors.models import Exhibitor, CatalogueIndustry, CatalogueValue, CatalogueBenefit, CatalogueLocation, CatalogueEmployment
 from banquet.models import Participant as BanquetParticipant
 from fair.models import Fair, LunchTicket
 
@@ -120,6 +120,33 @@ class CompleteLogisticsDetailsForm(ModelForm):
 
 
 class CompleteCatalogueDetailsForm(ModelForm):
+
+	catalogue_industries = forms.ModelMultipleChoiceField(
+		queryset = CatalogueIndustry.objects.filter(include_in_form = True),
+		widget = forms.CheckboxSelectMultiple,
+		label = 'Which industries does your company work in?',
+		required = False)
+	catalogue_values = forms.ModelMultipleChoiceField(
+		queryset = CatalogueValue.objects.filter(include_in_form = True),
+		widget = forms.CheckboxSelectMultiple,
+		label = 'Select up to three values that apply to the company.',
+		required = False)
+	catalogue_employments = forms.ModelMultipleChoiceField(
+		queryset = CatalogueEmployment.objects.filter(include_in_form = True),
+		widget = forms.CheckboxSelectMultiple,
+		label = 'What kind of employments does your company offer?',
+		required = False)
+	catalogue_locations = forms.ModelMultipleChoiceField(
+		queryset = CatalogueLocation.objects.filter(include_in_form = True),
+		widget = forms.CheckboxSelectMultiple,
+		label = 'Where does your company operate?',
+		required = False)
+	catalogue_benefits = forms.ModelMultipleChoiceField(
+		queryset = CatalogueBenefit.objects.filter(include_in_form = True),
+		widget = forms.CheckboxSelectMultiple,
+		label = 'Which benefits does your company offer its employees?',
+		required = False)
+
 	class Meta:
 		model = Exhibitor
 		fields = ['catalogue_about', 'catalogue_purpose', 'catalogue_logo_squared', 'catalogue_logo_freesize', 'catalogue_contact_name', 'catalogue_contact_email_address', 'catalogue_contact_phone_number', 'catalogue_industries', 'catalogue_values', 'catalogue_employments', 'catalogue_locations', 'catalogue_benefits', 'catalogue_average_age', 'catalogue_founded']
@@ -138,22 +165,12 @@ class CompleteCatalogueDetailsForm(ModelForm):
 			'catalogue_purpose': 'Your organisation\'s purpose',
 			'catalogue_logo_squared': 'Upload your company\'s squared logotype.',
 			'catalogue_logo_freesize': 'Upload your company\'s logotype in any dimensions, in addition to the squared logotype.',
-			'catalogue_industries': 'Which industries does your company work in?',
-			'catalogue_values': 'Select up to three values that apply to the company.',
-			'catalogue_employments': 'What kind of employments does your company offer?',
-			'catalogue_locations': 'Where does your company operate?',
-			'catalogue_benefits': 'Which benefits does your company offers its employees?',
 			'catalogue_founded': 'Which year was the company founded?'
 		}
 
 		widgets = {
 			'catalogue_about': forms.Textarea(attrs = {'maxlength': 600, 'rows': 3, 'placeholder': 'Concrete information about what your organisation does.'}),
 			'catalogue_purpose': forms.Textarea(attrs = {'maxlength': 600, 'rows': 3, 'placeholder': 'What does your organisation believe in?'}),
-			'catalogue_industries': forms.CheckboxSelectMultiple,
-			'catalogue_values': forms.CheckboxSelectMultiple,
-			'catalogue_employments': forms.CheckboxSelectMultiple,
-			'catalogue_locations': forms.CheckboxSelectMultiple,
-			'catalogue_benefits': forms.CheckboxSelectMultiple
 		}
 
 	def clean(self):


### PR DESCRIPTION
- Updated catalogue forms to only include alternatives that have the include_in_form set to True.
- Updated admin view to manage catalogue alternatives easier with regards to the new attribute.
- Sort catalogue alternatives in ascending order based on name always (defined in models.py).