### PR TITLE
added email address tab to CRM

### DIFF
--- a/companies/urls.py
+++ b/companies/urls.py
@@ -6,6 +6,7 @@ urlpatterns = [
 	url(r'^new$', views.companies_new, name = 'companies_new'),
 	url(r'^slack_call$', views.companies_slack_call, name = 'companies_slack_call'),
 	url(r'^statistics$', views.statistics, name = 'statistics'),
+	url(r'^email$', views.email, name = 'email'),
 	url(r'^groups$', views.groups, name = 'groups_list'),
 	url(r'^groups/new$', views.groups, name = 'groups_new'),
 	url(r'^groups/(?P<pk>\d+)$', views.groups, name = 'groups_edit'),

--- a/templates/companies/companies_list.html
+++ b/templates/companies/companies_list.html
@@ -12,10 +12,11 @@
 <h1>Companies</h1>
 
 <p>
-	<a href="{% url 'contracts_export' fair.year %}" type="button" class="btn btn-default"><span class="glyphicon glyphicon-list"></span> Export signatures</a>
 	<a href="{% url 'companies_list' fair.year %}" type="button" class="btn btn-default"><span class="glyphicon glyphicon-list"></span> Companies</a>
 	<a href="{% url 'groups_list' fair.year %}" type="button" class="btn btn-default"><span class="glyphicon glyphicon-list"></span> Groups</a>
 	<a href="{% url 'statistics' fair.year %}" type="button" class="btn btn-default"><span class="glyphicon glyphicon-list"></span> Statistics</a>
+	<a href="{% url 'email' fair.year %}" type="button" class="btn btn-default"><span class="glyphicon glyphicon-list"></span> Email addresses</a>
+	<a href="{% url 'contracts_export' fair.year %}" type="button" class="btn btn-default"><span class="glyphicon glyphicon-list"></span> Export signatures</a>
 </p>
 
 <style type="text/css">

--- a/templates/companies/contracts_export.html
+++ b/templates/companies/contracts_export.html
@@ -6,14 +6,15 @@
 
 {% block content %}
 	<h1>Export signatures</h1>
-	
+
 	<p>
-		<a href="{% url 'contracts_export' fair.year %}" type="button" class="btn btn-default"><span class="glyphicon glyphicon-list"></span> Export signatures</a>
 		<a href="{% url 'companies_list' fair.year %}" type="button" class="btn btn-default"><span class="glyphicon glyphicon-list"></span> Companies</a>
 		<a href="{% url 'groups_list' fair.year %}" type="button" class="btn btn-default"><span class="glyphicon glyphicon-list"></span> Groups</a>
 		<a href="{% url 'statistics' fair.year %}" type="button" class="btn btn-default"><span class="glyphicon glyphicon-list"></span> Statistics</a>
+		<a href="{% url 'email' fair.year %}" type="button" class="btn btn-default"><span class="glyphicon glyphicon-list"></span> Email addresses</a>
+		<a href="{% url 'contracts_export' fair.year %}" type="button" class="btn btn-default"><span class="glyphicon glyphicon-list"></span> Export signatures</a>
 	</p>
-	
+
 	<form method="post">
 		{% csrf_token %}
 		{{ form | crispy }}

--- a/templates/companies/email.html
+++ b/templates/companies/email.html
@@ -1,0 +1,36 @@
+{% extends "base.html" %}
+
+{% load crispy_forms_tags %}
+
+{% block nav-companies %}<li role="presentation" class="active"><a href="{% url 'companies_list' fair.year %}">CRM</a></li>{% endblock %}
+
+{% block content %}
+<h1>Email addresses</h1>
+
+<p>
+	<a href="{% url 'companies_list' fair.year %}" type="button" class="btn btn-default"><span class="glyphicon glyphicon-list"></span> Companies</a>
+	<a href="{% url 'groups_list' fair.year %}" type="button" class="btn btn-default"><span class="glyphicon glyphicon-list"></span> Groups</a>
+	<a href="{% url 'statistics' fair.year %}" type="button" class="btn btn-default"><span class="glyphicon glyphicon-list"></span> Statistics</a>
+	<a href="{% url 'email' fair.year %}" type="button" class="btn btn-default"><span class="glyphicon glyphicon-list"></span> Email addresses</a>
+	<a href="{% url 'contracts_export' fair.year %}" type="button" class="btn btn-default"><span class="glyphicon glyphicon-list"></span> Export signatures</a>
+</p>
+
+<style type="text/css">
+	textarea
+	{
+		height: 200px;
+		width: 100%;
+		box-sizing: border-box;
+		font-size: 12pt;
+	}
+</style>
+
+<p class = 'text-danger'>Make sure to use blind carbon copies (BCC) when sending e-mail messages to the contacts below.</p>
+
+{% for category in categories %}
+	<h2>{% if category.name %}{{ category.name }}{% else %}<span style="font-style: italic;">no status</span>{% endif %}</h2>
+	<p style="font-style: italic;">{% if category.help_text %}{{ category.help_text }}{% endif %}</p>
+	<textarea>{% for user in category.users %}{% if user.i != 1 %}, {% endif %}{{ user.name }} <{{ user.email_address }}>{% endfor %}</textarea>
+{% endfor %}
+
+{% endblock %}

--- a/templates/companies/groups.html
+++ b/templates/companies/groups.html
@@ -12,10 +12,11 @@
 <h1>Groups in {{ fair }}</h1>
 
 <p>
-	<a href="{% url 'contracts_export' fair.year %}" type="button" class="btn btn-default"><span class="glyphicon glyphicon-list"></span> Export signatures</a>
 	<a href="{% url 'companies_list' fair.year %}" type="button" class="btn btn-default"><span class="glyphicon glyphicon-list"></span> Companies</a>
 	<a href="{% url 'groups_list' fair.year %}" type="button" class="btn btn-default"><span class="glyphicon glyphicon-list"></span> Groups</a>
 	<a href="{% url 'statistics' fair.year %}" type="button" class="btn btn-default"><span class="glyphicon glyphicon-list"></span> Statistics</a>
+	<a href="{% url 'email' fair.year %}" type="button" class="btn btn-default"><span class="glyphicon glyphicon-list"></span> Email addresses</a>
+	<a href="{% url 'contracts_export' fair.year %}" type="button" class="btn btn-default"><span class="glyphicon glyphicon-list"></span> Export signatures</a>
 </p>
 
 <div class="row">
@@ -24,7 +25,7 @@
 			<div class="panel-heading">
 				<h3 class="panel-title">Groups</h3>
 			</div>
-			
+
 			<div class="panel-body">
 				{% for group in groups_list %}
 					{% if group == 'open' %}<ul>
@@ -41,14 +42,14 @@
 			</div>
 		</div>
 	</div>
-	
+
 	<div class="col-md-7">
 		{% if request.resolver_match.url_name != 'groups_list' %}
 			<div class="panel panel-default">
 				<div class="panel-heading">
 					<h3 class="panel-title">{% if form_group %} Edit group {% else %} New group {% endif %}</h3>
 				</div>
-				
+
 				<div class="panel-body">
 					<form method="post" enctype="multipart/form-data">
 						{% csrf_token %}

--- a/templates/companies/statistics.html
+++ b/templates/companies/statistics.html
@@ -8,10 +8,11 @@
 <h1>Statistics</h1>
 
 <p>
-	<a href="{% url 'contracts_export' fair.year %}" type="button" class="btn btn-default"><span class="glyphicon glyphicon-list"></span> Export signatures</a>
 	<a href="{% url 'companies_list' fair.year %}" type="button" class="btn btn-default"><span class="glyphicon glyphicon-list"></span> Companies</a>
 	<a href="{% url 'groups_list' fair.year %}" type="button" class="btn btn-default"><span class="glyphicon glyphicon-list"></span> Groups</a>
 	<a href="{% url 'statistics' fair.year %}" type="button" class="btn btn-default"><span class="glyphicon glyphicon-list"></span> Statistics</a>
+	<a href="{% url 'email' fair.year %}" type="button" class="btn btn-default"><span class="glyphicon glyphicon-list"></span> Email addresses</a>
+	<a href="{% url 'contracts_export' fair.year %}" type="button" class="btn btn-default"><span class="glyphicon glyphicon-list"></span> Export signatures</a>
 </p>
 
 <div class="table-responsive">


### PR DESCRIPTION
The CRM app now has the same functionality as the recruitment app where a user can view and copy all names and email addresses to groups of contacts.