### PR TITLE
Filter event list by fair year

### DIFF
--- a/events/views.py
+++ b/events/views.py
@@ -42,7 +42,7 @@ def save_questions(questions_data, event):
 @permission_required('events.base')
 def event_list(request, year):
     fair = get_object_or_404(Fair, year=year)
-    events = Event.objects.annotate(num_participants=Count('participant'))
+    events = Event.objects.annotate(num_participants=Count('participant')).filter(fair=fair)
 
     return render(request, 'events/event_list.html', {
         'fair': fair,


### PR DESCRIPTION
Currently, the event page in AIS shows events from 2018 in the list. Clicking on an event from 2018 while being at /ais.armada.nu/fairs/2019/events/ gives 'Server Error 500'. This fix will filter out the events for the current year only. Then Ella can start adding events for 2019 and not mix them up with events from 2018.