### PR TITLE
005 crm search parameters

### DIFF
--- a/companies/models.py
+++ b/companies/models.py
@@ -129,15 +129,10 @@ class Company(models.Model):
 		else:
 			return None
 
-	@property
-	def contacts(self):
-		return CompanyContact.objects.filter(company = self) # Unused. Slow compared to prefetch_related?
-
 	class Meta:
 		verbose_name_plural = "Companies"
 		ordering = ["name"]
 		permissions = (("base", "Companies"),)
-		# INDEXES: Potential performance gains?
 
 	def __str__(self):
 		return self.name

--- a/companies/models.py
+++ b/companies/models.py
@@ -129,10 +129,15 @@ class Company(models.Model):
 		else:
 			return None
 
+	@property
+	def contacts(self):
+		return CompanyContact.objects.filter(company = self) # Unused. Slow compared to prefetch_related?
+
 	class Meta:
 		verbose_name_plural = "Companies"
 		ordering = ["name"]
 		permissions = (("base", "Companies"),)
+		# INDEXES: Potential performance gains?
 
 	def __str__(self):
 		return self.name

--- a/companies/views.py
+++ b/companies/views.py
@@ -238,7 +238,7 @@ def companies_list(request, year):
 
 	has_filtering = request.POST and form.is_valid()
 
-	companies = Company.objects.prefetch_related('groups', 'companycontact_set', 'companyaddress_set')
+	companies = Company.objects.prefetch_related('groups', 'companycontact_set')
 
 	responsibles_list = list(CompanyCustomerResponsible.objects.select_related('company').select_related('group').filter(group__fair = fair).prefetch_related('users'))
 	responsibles = {}
@@ -318,6 +318,14 @@ def companies_list(request, year):
 				'emails': [contact['email_address'], contact['alternative_email_address']],
 				'numbers': [contact['mobile_phone_number'], contact['work_phone_number']] 
 			})
+			# The numbers all start with +46, it would be nice to able to search numbers 
+			# without the country code so for every number +46701234567, we append 0701234567.
+			# Note: some numbers do not have swedish country codes, and cannot be searched
+			# for with a leading 0.
+			for number in contacts[-1]['numbers']:
+				if number is not None and number[:3] == '+46':
+					contacts[-1]['numbers'].append(number.replace('+46', '0'))
+
 		
 		companies_modified.append({
 			'pk': company.pk,

--- a/templates/companies/companies_list.html
+++ b/templates/companies/companies_list.html
@@ -64,11 +64,15 @@
 	<input class="btn btn-primary" type="submit" value="Refine search" />
 </form>
 
+
 <div class="table-responsive">
 	<table class="table" id="company_table">
 		<thead>
 			<tr>
 				<th>Name</th>
+				<th>Contact</th>
+				<th>Phone</th>
+				<th>Email</th>
 				<th>Contracts</th>
 				<th>Groups</th>
 				<th>Responsibilities</th>
@@ -92,6 +96,31 @@
 						{% else %}<span class="label label-default">{% endif %}
 						{{ company.status.name }}</span>
 					{% endif %}
+				</td>
+
+				<td>
+					{% for contact in company.contacts %}
+						{{ contact.name }} <BR>
+					{% endfor %}
+				</td>
+
+				<td>
+					{% for contact in company.contacts %}
+						{% for number in contact.numbers %}
+							{% if number %} {{ number }} {% endif %} 
+						{% endfor %}
+						<BR>
+					{% endfor %}
+				</td>
+
+
+				<td>
+					{% for contact in company.contacts %}
+						{% for email in contact.emails %}
+							{% if email %}{{ email }} {% endif %} 
+						{% endfor %}
+						<BR>
+					{% endfor %}
 				</td>
 
 				<td>
@@ -136,7 +165,14 @@
 <script>
 	$(function()
 	{
-		$('#company_table').DataTable({ 'paging': false });
+		$('#company_table').DataTable({ 'paging': false,
+										'columnDefs': [
+										{
+											"targets": [1, 2, 3],
+											"visible": false
+										}
+										] 
+									});
 	})
 </script>
 {% endblock %}


### PR DESCRIPTION
Allows contact names, numbers and emails to be searched by the same search field as used to search the rest of the table. This is achieved by adding extra (hidden) columns to the table.

It certainly doesn't make the CRM faster, but I don't find the slow-down especially noticeable considering it's already pretty dismal...