### PR TITLE
090 update matching for 2019

### DIFF
--- a/api/deserializers.py
+++ b/api/deserializers.py
@@ -8,13 +8,12 @@ def matching(data):
     check the student answers data, validating the data on the way
     '''
     if type(data) is dict:
-        # TODO Filter on include in form?
         industries = CatalogueIndustry.objects.values_list('pk', flat=True)
         values = CatalogueValue.objects.values_list('pk', flat=True)
         employments = CatalogueEmployment.objects.values_list('pk', flat=True)
         locations = CatalogueLocation.objects.values_list('pk', flat=True)
         competences = CatalogueCompetence.objects.values_list('pk', flat=True)
-        #benefits = CatalogueValue.objects.values_list('pk', flat=True)
+
 
         validation_multi_set = {
             "industries" : industries,
@@ -22,21 +21,28 @@ def matching(data):
             "employments" : employments,
             "locations" : locations,
             "competences": competences,
-            #"cities": TODO
-            #"benefits" : benefits
         }
 
+        # Check that the values are lists and that
+        # they are subsets of the possible values.
+        # Also check that the weights, if given,
+        # don't sum to zero.
+        sum = 0
         for key, value_list in validation_multi_set.items():
             # check if list
-            if isinstance(data[key], (list,)):
+            if isinstance(data[key]["answer"], (list,)):
                 # can't be a subset if it's not an int
-                if not set(data[key]).issubset(set(value_list)):
+                if not set(data[key]["answer"]).issubset(set(value_list)):
                     return False
+                sum += data[key]["weight"]
             else:
                 return False
 
+        if (sum + data["cities"]["weight"] == 0):
+            return False
+
         # The cities value must be a string of comma-separated cities
-        if not isinstance(data["cities"], str):
+        if not isinstance(data["cities"]["answer"], str):
             return False
 
         return True

--- a/api/deserializers.py
+++ b/api/deserializers.py
@@ -38,8 +38,6 @@ def matching(data):
                     return False
 
                 if not "weight" in data[key]:
-                    return False
-                    
                     # The weight must be defined
                     return False
 
@@ -74,9 +72,9 @@ def matching(data):
         if non_empties == 0:
             return False
 
-        # The reponse_size variable must not be defined
+        # The reponse_size variable must not be defined...
         if "response_size" in data:
-        # but it can't be 0 or negative
+        # ... but it can't be 0 or negative
             if data["response_size"] <= 0:
                 return False
             else:

--- a/api/deserializers.py
+++ b/api/deserializers.py
@@ -1,25 +1,29 @@
 from django.shortcuts import get_object_or_404
 from matching.models import StudentQuestionBase, StudentQuestionType, StudentAnswerSlider, StudentAnswerGrading, WorkField, StudentAnswerWorkField, Continent, SwedenRegion, \
 StudentAnswerRegion, StudentAnswerContinent, JobType, StudentAnswerJobType
-from exhibitors.models import Exhibitor, CatalogueIndustry, CatalogueValue, CatalogueEmployment, CatalogueLocation, CatalogueBenefit
+from exhibitors.models import Exhibitor, CatalogueIndustry, CatalogueValue, CatalogueEmployment, CatalogueLocation, CatalogueCompetence#CatalogueBenefit
 
 def matching(data):
     '''
     check the student answers data, validating the data on the way
     '''
     if type(data) is dict:
+        # TODO Filter on include in form?
         industries = CatalogueIndustry.objects.values_list('pk', flat=True)
         values = CatalogueValue.objects.values_list('pk', flat=True)
         employments = CatalogueEmployment.objects.values_list('pk', flat=True)
-        locations = CatalogueEmployment.objects.values_list('pk', flat=True)
-        benefits = CatalogueValue.objects.values_list('pk', flat=True)
+        locations = CatalogueLocation.objects.values_list('pk', flat=True)
+        competences = CatalogueCompetence.objects.values_list('pk', flat=True)
+        #benefits = CatalogueValue.objects.values_list('pk', flat=True)
 
         validation_multi_set = {
             "industries" : industries,
             "values" : values,
             "employments" : employments,
             "locations" : locations,
-            "benefits" : benefits
+            "competences": competences,
+            #"cities": TODO
+            #"benefits" : benefits
         }
 
         for key, value_list in validation_multi_set.items():
@@ -30,6 +34,11 @@ def matching(data):
                     return False
             else:
                 return False
+
+        # The cities value must be a string of comma-separated cities
+        if not isinstance(data["cities"], str):
+            return False
+
         return True
     else:
         return False

--- a/api/deserializers.py
+++ b/api/deserializers.py
@@ -28,22 +28,50 @@ def matching(data):
         # they are subsets of the possible values.
         # Also check that the weights, if given,
         # don't sum to zero.
-        sum = 0
+        weight_sum = 0
+        non_empties = len(validation_multi_set) + 1 # Count cities too
         for key, value_list in validation_multi_set.items():
             # check if list
             if isinstance(data[key]["answer"], (list,)):
                 # can't be a subset if it's not an int
                 if not set(data[key]["answer"]).issubset(set(value_list)):
                     return False
-                sum += data[key]["weight"]
+
+                if not "weight" in data[key]:
+                    return False
+                    
+                    # The weight must be defined
+                    return False
+
+                if len(data[key]["answer"]) == 0:
+                    non_empties -= 1    
+                    # The weight will be forced to 0
+                else:
+                    weight_sum += data[key]["weight"] 
+
             else:
                 return False
 
-        if (sum + data["cities"]["weight"] == 0):
-            return False
-
         # The cities value must be a string of comma-separated cities
         if not isinstance(data["cities"]["answer"], str):
+            return False
+
+        if not "weight" in data["cities"]:
+            return False
+        
+        if data["cities"]["answer"] != "":
+            # There is actually an answer for cities
+            weight_sum += data["cities"]["weight"]
+        else:
+            # In this case, the weight will be forced to 0
+            non_empties -= 1
+
+        # Sum of weights must be non-zero for normalization to work
+        if weight_sum == 0:
+            return False
+
+        # At least SOME answer must provide information
+        if non_empties == 0:
             return False
 
         # The reponse_size variable must not be defined

--- a/api/deserializers.py
+++ b/api/deserializers.py
@@ -2,6 +2,7 @@ from django.shortcuts import get_object_or_404
 from matching.models import StudentQuestionBase, StudentQuestionType, StudentAnswerSlider, StudentAnswerGrading, WorkField, StudentAnswerWorkField, Continent, SwedenRegion, \
 StudentAnswerRegion, StudentAnswerContinent, JobType, StudentAnswerJobType
 from exhibitors.models import Exhibitor, CatalogueIndustry, CatalogueValue, CatalogueEmployment, CatalogueLocation, CatalogueCompetence#CatalogueBenefit
+from fair.models import current_fair
 
 def matching(data):
     '''
@@ -44,6 +45,20 @@ def matching(data):
         # The cities value must be a string of comma-separated cities
         if not isinstance(data["cities"]["answer"], str):
             return False
+
+        # The reponse_size variable must not be defined
+        if "response_size" in data:
+        # but it can't be 0 or negative
+            if data["response_size"] <= 0:
+                return False
+            else:
+                # It also can't be bigger than the number of exhibitors
+                # in the current fair
+                current_fair_id = current_fair()
+                if current_fair_id is None: current_fair_id = 4 # Default to 2019
+                max_response_size = Exhibitor.objects.filter(fair_id = current_fair_id).count()
+                if data["response_size"] > max_response_size:
+                    return False
 
         return True
     else:

--- a/api/serializers.py
+++ b/api/serializers.py
@@ -42,9 +42,15 @@ def obj_name(obj):
 def names(objects):
     return [obj_name(obj) for obj in objects.all()]
 
-
+# This seems unused. Seems like exhibitors/api.py is 
+# preferred. They are very similar.
 def exhibitor(request, exhibitor, company):
 	img_placeholder = request.GET.get('img_placeholder') == 'true'
+	
+	city_list = []
+	exhibitor_cities_str = exhibitor.catalogue_cities.all()
+	if exhibitor_cities_str is not None:
+		city_list += [city.strip() for city in exhibitor_cities_str.split(',')]
 	
 	return OrderedDict([
 		('id', exhibitor.pk),
@@ -62,11 +68,13 @@ def exhibitor(request, exhibitor, company):
 		('values', [{'id': value.pk, 'name': value.value} for value in exhibitor.catalogue_values.all()]),
 		('employments', [{'id': employment.pk, 'name': employment.employment} for employment in exhibitor.catalogue_employments.all()]),
 		('locations', [{'id': location.pk, 'name': location.location} for location in exhibitor.catalogue_locations.all()]),
-		('benefits', [{'id': benefit.pk, 'name': benefit.benefit} for benefit in exhibitor.catalogue_benefits.all()]),
+        ('competences', [{'id': competence.pk, 'name': competence.name} for competence in exhibitor.catalogue_competences.all()]),
+        ('cities', city_list),
+		#('benefits', [{'id': benefit.pk, 'name': benefit.benefit} for benefit in exhibitor.catalogue_benefits.all()]),
 		('average_age', exhibitor.catalogue_average_age),
 		('founded', exhibitor.catalogue_founded),
 		('groups', [{'id': group.pk, 'name': group.name} for group in company.groups.filter(fair = exhibitor.fair, allow_exhibitors = True)]),
-		('fair_locations', [])
+		('fair_locations', []) # Shouldn't this be something...?
 	])
 
 

--- a/api/serializers.py
+++ b/api/serializers.py
@@ -47,11 +47,6 @@ def names(objects):
 def exhibitor(request, exhibitor, company):
 	img_placeholder = request.GET.get('img_placeholder') == 'true'
 	
-	city_list = []
-	exhibitor_cities_str = exhibitor.catalogue_cities.all()
-	if exhibitor_cities_str is not None:
-		city_list += [city.strip() for city in exhibitor_cities_str.split(',')]
-	
 	return OrderedDict([
 		('id', exhibitor.pk),
 		('name', company.name),
@@ -68,9 +63,9 @@ def exhibitor(request, exhibitor, company):
 		('values', [{'id': value.pk, 'name': value.value} for value in exhibitor.catalogue_values.all()]),
 		('employments', [{'id': employment.pk, 'name': employment.employment} for employment in exhibitor.catalogue_employments.all()]),
 		('locations', [{'id': location.pk, 'name': location.location} for location in exhibitor.catalogue_locations.all()]),
-        ('competences', [{'id': competence.pk, 'name': competence.name} for competence in exhibitor.catalogue_competences.all()]),
-        ('cities', city_list),
-		#('benefits', [{'id': benefit.pk, 'name': benefit.benefit} for benefit in exhibitor.catalogue_benefits.all()]),
+        ('competences', [{'id': competence.pk, 'name': competence.competence} for competence in exhibitor.catalogue_competences.all()]),
+        ('cities', exhibitor.catalogue_cities),
+		('benefits', [{'id': benefit.pk, 'name': benefit.benefit} for benefit in exhibitor.catalogue_benefits.all()]),
 		('average_age', exhibitor.catalogue_average_age),
 		('founded', exhibitor.catalogue_founded),
 		('groups', [{'id': group.pk, 'name': group.name} for group in company.groups.filter(fair = exhibitor.fair, allow_exhibitors = True)]),

--- a/api/serializers.py
+++ b/api/serializers.py
@@ -64,7 +64,7 @@ def exhibitor(request, exhibitor, company):
 		('employments', [{'id': employment.pk, 'name': employment.employment} for employment in exhibitor.catalogue_employments.all()]),
 		('locations', [{'id': location.pk, 'name': location.location} for location in exhibitor.catalogue_locations.all()]),
         ('competences', [{'id': competence.pk, 'name': competence.competence} for competence in exhibitor.catalogue_competences.all()]),
-        ('cities', exhibitor.catalogue_cities),
+        ('cities', exhibitor.catalogue_cities if exhibitor.catalogue_cities is not None else ''),
 		('benefits', [{'id': benefit.pk, 'name': benefit.benefit} for benefit in exhibitor.catalogue_benefits.all()]),
 		('average_age', exhibitor.catalogue_average_age),
 		('founded', exhibitor.catalogue_founded),

--- a/api/urls.py
+++ b/api/urls.py
@@ -16,5 +16,6 @@ urlpatterns = [
     url(r'^recruitment/$', views.recruitment),
     url(r'^status/$', views.status),
     url(r'^student_profile$', views.student_profile),
-    url(r'^matching/$', views.matching)
+    url(r'^matching/$', views.matching),
+    url(r'^matching/choices$', views.matching_choices)
 ]

--- a/api/views.py
+++ b/api/views.py
@@ -70,13 +70,27 @@ def matching(request):
                 #     'similarity': matching_data[i]['similarity']
                 # } for i in matching_data]
 
-                response = {}
-
+                # Only serialize each exhibitor once, even if
+                # one exhibitor appears as a top choice in several cateogories.
+                exhibitors = {}
                 for category, similar_companies in matching_data.items():
-                    response[category] = [{
-                        'exhibitor': serialize_exhibitor(Exhibitor.objects.filter(pk = company['exhibitor_id']).first(), request),
-                        'similarity': company['similarity']
-                    } for company in similar_companies]
+                    for company in similar_companies:
+                        exhibitor_id = company['exhibitor_id']
+                        if exhibitor_id not in exhibitors:
+                            exhibitors[exhibitor_id] = serialize_exhibitor(Exhibitor.objects.filter(pk = exhibitor_id).first(), request)
+
+
+                response = {
+                    "similarities": matching_data,
+                    "exhibitors": exhibitors
+                }
+
+
+                # for category, similar_companies in matching_data.items():
+                #     response[category] = [{
+                #         'exhibitor': serialize_exhibitor(Exhibitor.objects.filter(pk = company['exhibitor_id']).first(), request),
+                #         'similarity': company['similarity']
+                #     } for company in similar_companies]
                 
                 return JsonResponse(response, safe = False)
                  

--- a/api/views.py
+++ b/api/views.py
@@ -126,6 +126,11 @@ def matching_choices(request):
         # on armada.nu/matching, we only change this, as long
         # as armada.nu does not ignore this information
         response['meta']['order'] = ['values', 'industries', 'competences', 'employments', 'locations']
+        
+        current_fair_id = current_fair()
+        if current_fair() is None: current_fair_id = 4 # Default to 2019
+        
+        response['meta']['max_response_size'] = Exhibitor.objects.filter(fair_id = current_fair_id).count()
 
         def append_component(key):
             if key == 'competences':

--- a/api/views.py
+++ b/api/views.py
@@ -33,7 +33,7 @@ def root(request):
 
 @csrf_exempt
 def matching(request):
-    # validera POST-indata så att de givna svaren faktiskt existerar
+    # Validate POST-input to make sure the given answers exist
     if request.method == 'POST':
         if request.body:
             try:
@@ -64,8 +64,8 @@ def matching(request):
                     print(matching_data[i])
 
                 response = [{
+                    # N.B: serialize_exhibitor is located in exhibitors/ and not here in api/serializers.py as one might expect
                     'exhibitor': serialize_exhibitor(Exhibitor.objects.filter(pk = matching_data[i]['exhibitor_id']).first(), request),
-                    #'exhibitor': serializers.exhibitor(Exhibitor.objects.filter(pk = matching_data[i]['exhibitor_id']).first(), request),
                     'similarity': matching_data[i]['similarity']
                 } for i in matching_data]
                 

--- a/api/views.py
+++ b/api/views.py
@@ -60,15 +60,7 @@ def matching(request):
                 with open(matching_path, 'r') as matching_file:
                     matching_data = json.load(matching_file)
                 
-                # for i in matching_data:
-                #     print(matching_data[i])
-                print(matching_data)
-
-                # response = [{
-                #     # N.B: serialize_exhibitor is located in exhibitors/ and not here in api/serializers.py as one might expect
-                #     'exhibitor': serialize_exhibitor(Exhibitor.objects.filter(pk = matching_data[i]['exhibitor_id']).first(), request),
-                #     'similarity': matching_data[i]['similarity']
-                # } for i in matching_data]
+                #print(matching_data) # Leaving this for debugging purposes
 
                 # Only serialize each exhibitor once, even if
                 # one exhibitor appears as a top choice in several cateogories.
@@ -79,19 +71,11 @@ def matching(request):
                         if exhibitor_id not in exhibitors:
                             exhibitors[exhibitor_id] = serialize_exhibitor(Exhibitor.objects.filter(pk = exhibitor_id).first(), request)
 
-
                 response = {
                     "similarities": matching_data,
                     "exhibitors": exhibitors
                 }
 
-
-                # for category, similar_companies in matching_data.items():
-                #     response[category] = [{
-                #         'exhibitor': serialize_exhibitor(Exhibitor.objects.filter(pk = company['exhibitor_id']).first(), request),
-                #         'similarity': company['similarity']
-                #     } for company in similar_companies]
-                
                 return JsonResponse(response, safe = False)
                  
             else:
@@ -117,14 +101,13 @@ def matching_choices(request):
         locations = CatalogueLocation.objects.filter(include_in_form=True).values('id', 'location')
 
         # We want to return a JSON object with the options the user has
-        response = {'options': [],
+        response = {
+                    'options': [],
                     'meta': {}
-                    }
+        }
 
-        # Indicates which order the questions come in.
-        # To change which order the questions are asked
-        # on armada.nu/matching, we only change this, as long
-        # as armada.nu does not ignore this information
+        # Indicates which order the questions/answers come in
+        # in the options list.
         response['meta']['order'] = ['values', 'industries', 'competences', 'employments', 'locations']
         
         current_fair_id = current_fair()

--- a/api/views.py
+++ b/api/views.py
@@ -59,10 +59,11 @@ def matching(request):
                 
                 for i in matching_data:
                     print(matching_data[i])
-                
+
                 response = [{
                     'exhibitor': serialize_exhibitor(Exhibitor.objects.filter(pk = matching_data[i]['exhibitor_id']).first(), request),
-                    'distance': matching_data[i]['distance']
+                    #'exhibitor': serializers.exhibitor(Exhibitor.objects.filter(pk = matching_data[i]['exhibitor_id']).first(), request),
+                    'similarity': matching_data[i]['similarity']
                 } for i in matching_data]
                 
                 return JsonResponse(response, safe = False)
@@ -77,7 +78,8 @@ def matching(request):
 # to present the questions that the user should answer.
 # the response holds the questions, as well as 
 # the order in which they come.
-@cache_page(1)
+@cache_page(60*15)
+@csrf_exempt
 def matching_choices(request):
     if request.method == 'GET':
 

--- a/api/views.py
+++ b/api/views.py
@@ -60,14 +60,23 @@ def matching(request):
                 with open(matching_path, 'r') as matching_file:
                     matching_data = json.load(matching_file)
                 
-                for i in matching_data:
-                    print(matching_data[i])
+                # for i in matching_data:
+                #     print(matching_data[i])
+                print(matching_data)
 
-                response = [{
-                    # N.B: serialize_exhibitor is located in exhibitors/ and not here in api/serializers.py as one might expect
-                    'exhibitor': serialize_exhibitor(Exhibitor.objects.filter(pk = matching_data[i]['exhibitor_id']).first(), request),
-                    'similarity': matching_data[i]['similarity']
-                } for i in matching_data]
+                # response = [{
+                #     # N.B: serialize_exhibitor is located in exhibitors/ and not here in api/serializers.py as one might expect
+                #     'exhibitor': serialize_exhibitor(Exhibitor.objects.filter(pk = matching_data[i]['exhibitor_id']).first(), request),
+                #     'similarity': matching_data[i]['similarity']
+                # } for i in matching_data]
+
+                response = {}
+
+                for category, similar_companies in matching_data.items():
+                    response[category] = [{
+                        'exhibitor': serialize_exhibitor(Exhibitor.objects.filter(pk = company['exhibitor_id']).first(), request),
+                        'similarity': company['similarity']
+                    } for company in similar_companies]
                 
                 return JsonResponse(response, safe = False)
                  

--- a/api/views.py
+++ b/api/views.py
@@ -21,7 +21,7 @@ import api.serializers as serializers
 
 from exhibitors.models import Exhibitor, CatalogueIndustry, CatalogueValue, CatalogueEmployment, CatalogueLocation, CatalogueCompetence #CatalogueBenefit
 from exhibitors.api import serialize_exhibitor
-from fair.models import Partner, Fair
+from fair.models import Partner, Fair, current_fair
 from matching.models import StudentQuestionBase as QuestionBase, WorkField, Survey
 from news.models import NewsArticle
 from recruitment.models import RecruitmentPeriod, RecruitmentApplication
@@ -50,7 +50,10 @@ def matching(request):
 
                 with open(random_doc_name, 'w') as outfile:
                     json.dump(data, outfile)
-                retrieved = subprocess.Popen(["python3", matching_script_loc, docID, random_doc_name],stdout=subprocess.PIPE)
+                fair_id = current_fair()
+                if current_fair() is None: fair_id = 4 # Default to 2019
+                
+                retrieved = subprocess.Popen(["python3", matching_script_loc, docID, random_doc_name, str(fair_id)],stdout=subprocess.PIPE)
                 # have to wait for subprocess to finish
                 retrieved.wait()
                 matching_path = os.path.join("/tmp/", docID + "_output.json")
@@ -83,7 +86,7 @@ def matching(request):
 def matching_choices(request):
     if request.method == 'GET':
 
-        # Get the choices that are relevant for this years fair
+        # Get the choices that we include in the company forms
         competences = CatalogueCompetence.objects.filter(include_in_form=True).values('id', 'competence')
         employments = CatalogueEmployment.objects.filter(include_in_form=True).values('id', 'employment')
         values = CatalogueValue.objects.filter(include_in_form=True).values('id', 'value')

--- a/exhibitors/api.py
+++ b/exhibitors/api.py
@@ -18,11 +18,6 @@ MISSING_IMAGE = '/static/missing.png'
 def serialize_exhibitor(exhibitor, request):
     img_placeholder = request.GET.get('img_placeholder') == 'true'
 
-    city_list = []
-    exhibitor_cities_str = exhibitor.catalogue_cities
-    if exhibitor_cities_str is not None and exhibitor_cities_str: # Can't be None or empty string
-        city_list += [city.strip() for city in exhibitor_cities_str.split(',')]
-
     return OrderedDict([
         ('id', exhibitor.pk),
         ('name', exhibitor.company.name),
@@ -42,8 +37,8 @@ def serialize_exhibitor(exhibitor, request):
         ('employments', [{'id': employment.pk, 'name': employment.employment} for employment in exhibitor.catalogue_employments.all()]),
         ('locations', [{'id': location.pk, 'name': location.location} for location in exhibitor.catalogue_locations.all()]),
         ('competences', [{'id': competence.pk, 'name': competence.competence} for competence in exhibitor.catalogue_competences.all()]),
-        ('cities', city_list),
-        #('benefits', [{'id': benefit.pk, 'name': benefit.benefit} for benefit in exhibitor.catalogue_benefits.all()]),
+        ('cities', exhibitor.catalogue_cities if exhibitor.catalogue_cities is not None else ''),
+        ('benefits', [{'id': benefit.pk, 'name': benefit.benefit} for benefit in exhibitor.catalogue_benefits.all()]),
         ('average_age', exhibitor.catalogue_average_age),
         ('founded', exhibitor.catalogue_founded),
         ('groups',

--- a/exhibitors/api.py
+++ b/exhibitors/api.py
@@ -18,6 +18,11 @@ MISSING_IMAGE = '/static/missing.png'
 def serialize_exhibitor(exhibitor, request):
     img_placeholder = request.GET.get('img_placeholder') == 'true'
 
+    city_list = []
+    exhibitor_cities_str = exhibitor.catalogue_cities
+    if exhibitor_cities_str is not None and exhibitor_cities_str: # Can't be None or empty string
+        city_list += [city.strip() for city in exhibitor_cities_str.split(',')]
+
     return OrderedDict([
         ('id', exhibitor.pk),
         ('name', exhibitor.company.name),
@@ -36,7 +41,9 @@ def serialize_exhibitor(exhibitor, request):
         ('values', [{'id': value.pk, 'name': value.value} for value in exhibitor.catalogue_values.all()]),
         ('employments', [{'id': employment.pk, 'name': employment.employment} for employment in exhibitor.catalogue_employments.all()]),
         ('locations', [{'id': location.pk, 'name': location.location} for location in exhibitor.catalogue_locations.all()]),
-        ('benefits', [{'id': benefit.pk, 'name': benefit.benefit} for benefit in exhibitor.catalogue_benefits.all()]),
+        ('competences', [{'id': competence.pk, 'name': competence.competence} for competence in exhibitor.catalogue_competences.all()]),
+        ('cities', city_list),
+        #('benefits', [{'id': benefit.pk, 'name': benefit.benefit} for benefit in exhibitor.catalogue_benefits.all()]),
         ('average_age', exhibitor.catalogue_average_age),
         ('founded', exhibitor.catalogue_founded),
         ('groups',

--- a/exhibitors/serializers.py
+++ b/exhibitors/serializers.py
@@ -22,6 +22,8 @@ def exhibitor(request, exhibitor, company):
         'values': [{'id': value.pk, 'name': value.value} for value in exhibitor.catalogue_values.all()],
         'employments': [{'id': employment.pk, 'name': employment.employment} for employment in exhibitor.catalogue_employments.all()],
         'locations': [{'id': location.pk, 'name': location.location} for location in exhibitor.catalogue_locations.all()],
+        'competences': [{'id': competence.pk, 'name': competence.competence} for competence in exhibitor.catalogue_competences.all()],
+        'cities': exhibitor.catalogue_cities if exhibitor.catalogue_cities is not None else '',
         'benefits': [{'id': benefit.pk, 'name': benefit.benefit} for benefit in exhibitor.catalogue_benefits.all()],
         'average_age': exhibitor.catalogue_average_age,
         'founded': exhibitor.catalogue_founded,


### PR DESCRIPTION
Update the matching API and use the updated matching algorithm. Also added API for getting the choices to the front end so that they don't have to be hard-coded.

N.B. This is dependent on the [related pull request in the matching repo](https://github.com/armada-ths/matching/pull/2).

The new algorithm is documented [here](https://drive.google.com/open?id=1oFa7uJOVBTqALeaXi_P2GkPNsfHojGa2wMzN_I3hk6o). The updated API documentation resides [here](https://drive.google.com/open?id=1Ks8_eDOseTeqZCsk1hSYN0tRHo84m3ysAPgEi2BwW20).

I updated exhibitor serialization wherever I came across it... So in exhibitors/api.py, exhibitors/serializers.py and api/serializers.py.