### PR TITLE
126 Stripe payment bugs fixed

### DIFF
--- a/banquet/views.py
+++ b/banquet/views.py
@@ -752,7 +752,7 @@ def external_invitation(request, token):
     if can_edit:
         if request.POST and form.is_valid():
 
-            if invitation.price > 0 and (invitation.participant is None or invitation.participant_has_paid == False) and intent == None: # should pay a price and has not dne this already
+            if invitation.price > 0 and (invitation.participant is None or invitation.participant.has_paid == False) and intent == None: # should pay a price and has not dne this already
                 stripe.api_key = settings.STRIPE_SECRET
                 # Create a Stripe payment intent https://stripe.com/docs/payments/payment-intents/we
                 intent = stripe.PaymentIntent.create(

--- a/payments/urls.py
+++ b/payments/urls.py
@@ -7,5 +7,6 @@ from django.conf.urls.static import  static
 urlpatterns = [
     url(r'^checkout$', views.checkout, name='checkout'),
     url(r'^confirm$', views.confirm, name='confirm'),
+	url(r'^cancel$', views.cancel, name='cancel'),
     #url(r'^gör en ny url-path views.check_payment_status name='check_payment_status')
 ]

--- a/payments/urls.py
+++ b/payments/urls.py
@@ -7,6 +7,4 @@ from django.conf.urls.static import  static
 urlpatterns = [
     url(r'^checkout$', views.checkout, name='checkout'),
     url(r'^confirm$', views.confirm, name='confirm'),
-	url(r'^cancel$', views.cancel, name='cancel'),
-    #url(r'^gör en ny url-path views.check_payment_status name='check_payment_status')
 ]

--- a/payments/views.py
+++ b/payments/views.py
@@ -72,3 +72,11 @@ def confirm(request):
         pass
 
     return redirect('../banquet/' + invitation_token)
+
+def cancel(request):
+    try:
+        invitation_token = request.session['invitation_token']
+    except KeyError:
+        raise Http404
+    print("inside cancel function YAY")
+    return redirect('../banquet/' + invitation_token)

--- a/payments/views.py
+++ b/payments/views.py
@@ -48,19 +48,18 @@ def confirm(request):
     if stripe.PaymentIntent.retrieve(id)['status'] != 'succeeded':
         invitation.participant.has_paid = False
         invitation.participant.save()
-
+        # if we are unable to get status succeeded we send an email to support, the issue then has to be handled manually
         send_mail(
-        'Problem with a payment in Stripe',
-        'There have been a problem with the charge for the token ' + invitation_token + ' and the intent id ' + id,
-        'noreply@armada.nu',
-        ['support@armada.nu'],
-        fail_silently=False,
+            'Problem with a payment in Stripe',
+            'There have been a problem with the charge for the token ' + invitation_token + ' and the intent id ' + id,
+            'noreply@armada.nu',
+            ['support@armada.nu'],
+            fail_silently=False,
         )
 
     else:
         invitation.participant.has_paid = True
         invitation.participant.save()
-
 
     try:
         del request.session['intent']
@@ -71,12 +70,4 @@ def confirm(request):
     except KeyError:
         pass
 
-    return redirect('../banquet/' + invitation_token)
-
-def cancel(request):
-    try:
-        invitation_token = request.session['invitation_token']
-    except KeyError:
-        raise Http404
-    print("inside cancel function YAY")
     return redirect('../banquet/' + invitation_token)

--- a/payments/views.py
+++ b/payments/views.py
@@ -9,7 +9,7 @@ from banquet.models import Participant, Invitation
 
 def checkout(request):
     stripe.api_key = settings.STRIPE_SECRET
-    stripe.api_version = '2019-09-09'
+    # stripe.api_version = '2019-09-09'
 
     try:
         intent = request.session['intent']

--- a/templates/banquet/invitation_external.html
+++ b/templates/banquet/invitation_external.html
@@ -58,7 +58,7 @@
 					<form method="post">
 						{% csrf_token %}
 						{{ form | crispy }}
-						
+
 						{% if invitation.part_of_matching and form_catalogue_details %}
 							<h2>Seating</h2>
 							<p>The seating at the banquet will be made to match your interests and academic background with companies relevant to you. The questions below are optional but we encourage you to fill them out in order to let our table matching algorithm do it's magic! The collected data will only be used for the banquet seating placement.</p>
@@ -67,9 +67,7 @@
 
 						{% if charge %}
 							<p><span style="font-weight: bold;">Total to pay:</span> SEK {{ invitation.price }}</p>
-							<button type="submit" class="btn btn-lg btn-success center-block">Proceed to payment</button>
-							<!--här vill vi skicka oss vidare till betalningsvyn-->
-							<!--<script src="https://checkout.stripe.com/checkout.js" class="stripe-button" onclick="checkout" data-currency="sek" data-key="{{ stripe_publishable }}" data-label="Proceed to payment" data-email="{{ invitation.email_address }}" data-allow-remember-me="false" data-name="THS Armada" data-description="{{ invitation.banquet.name }}" data-amount="{{ stripe_amount }}" data-locale="en"></script>-->
+							<button type="submit" class="btn btn-lg btn-success center-block">Proceed to Payment</button>
 						{% else %}
 							<button type="submit" class="btn btn-lg btn-success center-block">{% if invitation.participant %}Save changes{% else %}Submit{% endif %}</button>
 						{% endif %}

--- a/templates/payments/checkout.html
+++ b/templates/payments/checkout.html
@@ -38,6 +38,7 @@
   <script src="https://js.stripe.com/v3/"></script>
 
   <script>
+		// Client side of Stripe payment intent https://stripe.com/docs/payments/payment-intents/web
     var stripe = Stripe("{{ stripe_publishable }}", {locale : 'en'});
 		var payment_submission = false;
 
@@ -93,16 +94,6 @@
 				document.getElementById('name-error').className = "alert alert-danger";
 			}
     });
-
-		window.onbeforeunload = function(){
-			if (!payment_submission) {
-				// OBS - NOT WORKING ATM
-				console.log("Inside onbeforeunload function");
-				// window.location.href="{% url 'cancel' %}";
-				// window.location.href="https://google.com";
-				return ('Are you sure you want to leave?');
-			}
-		};
   </script>
 </head>
 

--- a/templates/payments/checkout.html
+++ b/templates/payments/checkout.html
@@ -39,6 +39,7 @@
 
   <script>
     var stripe = Stripe("{{ stripe_publishable }}", {locale : 'en'});
+		var payment_submission = false;
 
 		var style = {
 		  base: {
@@ -81,6 +82,7 @@
 						message_field.className = "alert alert-danger"
 						message_field.innerHTML = '<span style="font-weight: bold;">Something went wrong:</span> '.concat(message);
 					} else {
+						payment_submission = true;
 						message_field.className = "alert alert-success";
 						message_field.innerHTML = 'Payment suceeded, thank you!';
 						window.location.href="{% url 'confirm' %}";
@@ -91,6 +93,16 @@
 				document.getElementById('name-error').className = "alert alert-danger";
 			}
     });
+
+		window.onbeforeunload = function(){
+			if (!payment_submission) {
+				// OBS - NOT WORKING ATM
+				console.log("Inside onbeforeunload function");
+				// window.location.href="{% url 'cancel' %}";
+				// window.location.href="https://google.com";
+				return ('Are you sure you want to leave?');
+			}
+		};
   </script>
 </head>
 


### PR DESCRIPTION
Some edits had to be made to the previous pull request of the Stripe payment update. With the new updates we avoid creating more than one payment intent per invited person.

The payment method now works for external users that are invited to the banquet. Note that internal invitations, after party tickets and event payments still has to be updated.