### PR TITLE
Banquet invitation status update

### DIFF
--- a/banquet/forms.py
+++ b/banquet/forms.py
@@ -194,6 +194,7 @@ class InvitationForm(forms.ModelForm):
 class InvitationSearchForm(forms.Form):
 	status_choices = [
 		('GOING', 'Going'),
+		('HAS_NOT_PAID', 'Has not paid'),
 		('NOT_GOING', 'Not going'),
 		('PENDING', 'Pending')
 	]

--- a/banquet/models.py
+++ b/banquet/models.py
@@ -119,7 +119,10 @@ class Invitation(models.Model):
     @property
     def status(self):
         if self.participant is not None:
-            return 'GOING'
+            if  (self.price > 0) and (not self.participant.has_paid):
+                return 'HAS_NOT_PAID'
+            else:
+                return 'GOING'
         elif self.denied:
             return 'NOT_GOING'
         else:

--- a/banquet/views.py
+++ b/banquet/views.py
@@ -523,7 +523,8 @@ def manage_participant(request, year, banquet_pk, participant_pk):
 			'alcohol': participant.get_alcohol_display,
 			'giveaway': participant.get_giveaway_display,
             'token': participant.token,
-            'seat': participant.seat
+            'seat': participant.seat,
+			'invitation_status': participant.invitation_set.first().status,
         }
     })
 
@@ -540,7 +541,8 @@ def manage_participants(request, year, banquet_pk):
         'name': participant.user.get_full_name() if participant.user else participant.name,
         'email_address': participant.user.email if participant.user else participant.email_address,
         'alcohol': participant.alcohol,
-        'seat': participant.seat
+        'seat': participant.seat,
+        'invitation': participant.invitation_set.first(),
     } for participant in Participant.objects.select_related('seat').select_related('seat__table').filter(banquet=banquet)]
 
     return render(request, 'banquet/manage_participants.html', {

--- a/banquet/views.py
+++ b/banquet/views.py
@@ -387,7 +387,6 @@ def manage_invitations(request, year, banquet_pk):
             'reason': invitation.reason,
             'status': invitation.status,
             'price': invitation.price,
-            'status': invitation.status,
             'deadline_smart': invitation.deadline_smart,
             'matching_status': invitation.part_of_matching
         })

--- a/templates/banquet/invitation_external.html
+++ b/templates/banquet/invitation_external.html
@@ -29,6 +29,7 @@
 					<li>
 						<span style="font-weight: bold;">Invitation status:</span>
 						{% if invitation.status == 'GOING' %}<span class="label label-success">You are going</span>{% endif %}
+						{% if invitation.status == 'HAS_NOT_PAID' %}<span class="label label-warning">Has not paid</span>{% endif %}
 						{% if invitation.status == 'NOT_GOING' %}<span class="label label-danger">You are not going</span>{% endif %}
 						{% if invitation.status == 'PENDING' %}<span class="label label-default">Your invitation is pending response</span>{% endif %}
 					</li>

--- a/templates/banquet/invitation_internal.html
+++ b/templates/banquet/invitation_internal.html
@@ -20,6 +20,7 @@
 		<li>
 			<span style="font-weight: bold;">Invitation status:</span>
 			{% if invitation.status == 'GOING' %}<span class="label label-success">You are going</span>{% endif %}
+			{% if invitation.status == 'HAS_NOT_PAID' %}<span class="label label-warning">Has not paid</span>{% endif %}
 			{% if invitation.status == 'NOT_GOING' %}<span class="label label-danger">You are not going</span>{% endif %}
 			{% if invitation.status == 'PENDING' %}<span class="label label-default">Your invitation is pending response</span>{% endif %}
 		</li>

--- a/templates/banquet/manage_invitation.html
+++ b/templates/banquet/manage_invitation.html
@@ -6,13 +6,13 @@
 
 {% block content %}
 	<h1>{{ banquet.name }} – Invitation</h1>
-	
+
 	<p>
 		<a class="btn btn-default" href="{% url 'banquet_manage_invitations' fair.year banquet.pk %}">Invitations</a>
 		<a class="btn btn-default" href="{% url 'banquet_manage_participants' fair.year banquet.pk %}">Participants</a>
 		{% if banquet.background %} <a class="btn btn-default" href="{% url 'banquet_manage_map' fair.year banquet.pk %}">Map</a> {% endif %}
 	</p>
-	
+
 	<ul class="list-unstyled">
 		<li><span style="font-weight: bold;">Group:</span> {{ invitation.group }}</li>
 		<li><span style="font-weight: bold;">Deadline:</span> {% if invitation.deadline_smart %} {{ invitation.deadline_smart }} {% else %} <span style="font-style: italic;">no deadline</span> {% endif %}</li>
@@ -20,20 +20,21 @@
 		<li><span style="font-weight: bold;">E-mail address:</span> {% if invitation.user is None %} <a href="mailto:{{ invitation.email_address }}">{{ invitation.email_address }}</a> {% else %} <a href="mailto:{{ invitation.user.email }}">{{ invitation.user.email }}</a> {% endif %}</li>
 		<li
 			><span style="font-weight: bold;">Status:</span>
-			
+
 			{% if invitation.status == 'GOING' %}<span class="text-success">Going</span> <!--– <a href="#">view participation data</a>-->{% endif %}
+			{% if invitation.status == 'HAS_NOT_PAID' %}<span class="text-warning">Has not paid</span>{% endif %}
 			{% if invitation.status == 'NOT_GOING' %}<span class="text-danger">Not going</span>{% endif %}
 			{% if invitation.status == 'PENDING' %}<span class="text-default">Pending</span>{% endif %}
 		</li>
 		<li><span style="font-weight: bold;">Part of matching:</span> {{ invitation.get_part_of_matching_display }}</li>
 	</ul>
-	
+
 	<a href="{% url 'banquet_manage_invitation_edit' fair.year banquet.pk invitation.pk %}" class="btn btn-default">Edit invitation</a>
-	
+
 	<h2>Invitation link</h2>
 	{% if invitation.user is None %}
 		<p>Give the following link to the invitee.</p>
-		
+
 		<input type="text" value="https://ais.armada.nu{% url 'banquet_external_invitation' invitation.token %}" />
 	{% else %}
 		<p>This invitation is tied to a user account. Ask {{ invitation.user.get_full_name }} to sign in to the AIS and click Banquet in the menu.</p>

--- a/templates/banquet/manage_invitations.html
+++ b/templates/banquet/manage_invitations.html
@@ -8,15 +8,15 @@
 
 {% block content %}
 	<h1>{{ banquet.name }} – Invitations</h1>
-	
+
 	<p>
 		<a class="btn btn-default" href="{% url 'banquet_manage_invitations' fair.year banquet.pk %}">Invitations</a>
 		<a class="btn btn-default" href="{% url 'banquet_manage_participants' fair.year banquet.pk %}">Participants</a>
 		{% if banquet.background %} <a class="btn btn-default" href="{% url 'banquet_manage_map' fair.year banquet.pk %}">Map</a> {% endif %}
-		
+
 		<a style="float: right;" class="btn btn-default" href="{% url 'banquet_manage_invitation_new' fair.year banquet.pk %}">New invitation</a>
 	</p>
-	
+
 	<style type="text/css">
 		.form_no_ul ul
 		{
@@ -24,27 +24,27 @@
 			padding: 0;
 			margin: 0 0 20px 15px;
 		}
-		
+
 		.form_no_ul ul li
 		{
 			list-style-type: none;
 		}
-		
+
 		.form_no_ul ul li label
 		{
 			font-weight: 400;
 		}
 	</style>
-	
+
 	<form method="post" class="form_no_ul" enctype="multipart/form-data">
 		{% csrf_token %}
-		
+
 		<div class="row">
 			<div class="col-md-6">
 				<label for="{{ form.statuses.id_for_label }}">{{ form.statuses.label }}</label>
 				{{ form.statuses }}
 			</div>
-			
+
 			<div class="col-md-6">
 				<label for="{{ form.groups.id_for_label }}">{{ form.groups.label }}</label>
 				{{ form.groups }}
@@ -55,10 +55,10 @@
 				{{ form.matching_statuses }}
 			</div>
 		</div>
-		
+
 		<input class="btn btn-primary" type="submit" value="Refine search" />
 	</form>
-	
+
 	<div class="table-responsive">
 		<table class="table" id="invitation_table">
 			<thead>
@@ -72,7 +72,7 @@
 					<th></th>
 				</tr>
 			</thead>
-			
+
 			<tbody>
 				{% for invitation in invitiations %}
 					<tr>
@@ -80,8 +80,9 @@
 						<td>{% if invitation.deadline_smart is not None %} <span style="display: none;">{{ invitation.deadline_smart|date:"U" }}</span> {{ invitation.deadline_smart }} {% else %} <span style="font-style: italic;">no deadline</span> {% endif %}</td>
 						<td>
 							{% if invitation.user %} <a href="{% url 'people:profile' fair.year invitation.user.pk %}">{{ invitation.name }}</a> {% else %} {{ invitation.name }} {% endif %}
-							
+
 							{% if invitation.status == 'GOING' %}<span class="label label-success">Going</span>{% endif %}
+							{% if invitation.status == 'HAS_NOT_PAID' %}<span class="label label-warning">Has not paid</span>{% endif %}
 							{% if invitation.status == 'NOT_GOING' %}<span class="label label-danger">Not going</span>{% endif %}
 							{% if invitation.status == 'PENDING' %}<span class="label label-default">Pending</span>{% endif %}
 						</td>

--- a/templates/banquet/manage_participant.html
+++ b/templates/banquet/manage_participant.html
@@ -34,6 +34,9 @@
 	{% else %}
 		<p class="text-danger">The participant has no seat.</p>
 	{% endif %}
+	{% if participant.invitation_status == 'HAS_NOT_PAID' %}
+		<p class="text-danger"><span style="font-weight: bold;">The participant has not paid yet.</span></p>
+	{% endif %}
 
 	<p>
 		<a href="{% url 'banquet_manage_participant_remove' fair.year banquet.pk participant.pk %}" class="btn btn-danger" onclick="return confirm('Confirm the removal of {{ participant.name }}.');">Remove participant</a>

--- a/templates/banquet/manage_participants.html
+++ b/templates/banquet/manage_participants.html
@@ -6,13 +6,13 @@
 
 {% block content %}
 	<h1>{{ banquet.name }} – Participants ({{ participants | length }})</h1>
-	
+
 	<p>
 		<a class="btn btn-default" href="{% url 'banquet_manage_invitations' fair.year banquet.pk %}">Invitations</a>
 		<a class="btn btn-default" href="{% url 'banquet_manage_participants' fair.year banquet.pk %}">Participants</a>
 		{% if banquet.background %} <a class="btn btn-default" href="{% url 'banquet_manage_map' fair.year banquet.pk %}">Map</a> {% endif %}
 	</p>
-	
+
 	<div class="table-responsive">
 		<table class="table" id="participation_table">
 			<thead>
@@ -25,12 +25,21 @@
 					<th style="text-align: right;">Options</th>
 				</tr>
 			</thead>
-			
+
 			<tbody>
 				{% for participant in participants %}
 					<tr>
 						<td>{% if participant.company %} {{ participant.company }} {% endif %}</td>
-						<td>{% if participant.user %} <a href="{% url 'people:profile' fair.year participant.user.pk %}">{{ participant.name }}</a> {% else %} {{ participant.name }} {% endif %}</td>
+						<td>
+							{% if participant.user %}
+								<a href="{% url 'people:profile' fair.year participant.user.pk %}">{{ participant.name }}</a>
+							{% else %}
+								{{ participant.name }}
+							{% endif %}
+							{% if participant.invitation.status == 'HAS_NOT_PAID' %}
+								<span class="label label-warning">Has not paid</span>
+							{% endif %}
+						</td>
 						<td><a href="mailto:{{ participant.email_address }}">{{ participant.email_address }}</a></td>
 						<td>{% if participant.alcohol %} Yes {% else %} No {% endif %}</td>
 						<td style="white-space: nowrap;">{% if participant.seat %} {{ participant.seat.table.name }} – {{ participant.seat.name }} {% endif %}</td>


### PR DESCRIPTION
With the new payment solution for banquet tickets a user can become a participant and not have paid - some middle land in between Going and Not going. For this I have added a new invitation status "Has not paid" which is set if there is a participant buth this participant has not paid yet.

Normally a user should press the "Not going" button if he or she does not want to attend the banquet, and this will remove the participant, And hopefully everyone who press the "Proceed to payment" button intends to finish their signup. So the "Has not paid" should rarely be the case, but if so we can now see it both in the invitations view and in the participants view.