### PR TITLE
091 update exhibitors api

### DIFF
--- a/exhibitors/api.py
+++ b/exhibitors/api.py
@@ -47,7 +47,7 @@ def serialize_exhibitor(exhibitor, request):
         ('vyer_position', exhibitor.vyer_position if exhibitor.vyer_position else ''),
         ('location_special', str(exhibitor.fair_location_special) if exhibitor.fair_location_special else ''),
         ('climate_compensation', exhibitor.climate_compensation),
-        ('flyer', (exhibitor.flyer.url) if exhibitor.flyer else (MISSING_IMAGE if img_placeholder else None)),
+        ('flyer', (exhibitor.flyer.url) if exhibitor.flyer else ''),
         ('booths', [{
             'id': eib.booth.pk,
             'location': {

--- a/exhibitors/api.py
+++ b/exhibitors/api.py
@@ -64,7 +64,7 @@ def serialize_exhibitor(exhibitor, request):
 def exhibitors(request):
     data = []
 
-    for exhibitor in Exhibitor.objects.filter(fair=Fair.objects.get(year = 2018)): #Changed from current = True
+    for exhibitor in Exhibitor.objects.filter(fair=Fair.objects.get(current = True)):
         data.append(serialize_exhibitor(exhibitor, request))
 
     return JsonResponse(data, safe=False)
@@ -73,7 +73,7 @@ def exhibitors(request):
 def locations(request):
     data = []
 
-    for location in Location.objects.filter(fair__year = 2018): #Changed from current = True
+    for location in Location.objects.filter(fair__current = True):
         data.append({
             'id': location.pk,
             'parent': {
@@ -88,7 +88,7 @@ def locations(request):
 
 
 def location(request, location_pk):
-    location = get_object_or_404(Location, fair__year = 2018, pk=location_pk) #Changed from current=True
+    location = get_object_or_404(Location, fair__current = True, pk=location_pk)
 
     booths = []
 
@@ -130,7 +130,7 @@ def location(request, location_pk):
 def days(request):
     data = []
 
-    for day in FairDay.objects.filter(fair__year = 2018): #Changed from current = True
+    for day in FairDay.objects.filter(fair__current = True):
         data.append({
             'id': day.pk,
             'date': day.date

--- a/exhibitors/api.py
+++ b/exhibitors/api.py
@@ -48,7 +48,6 @@ def serialize_exhibitor(exhibitor, request):
         ('location_special', str(exhibitor.fair_location_special) if exhibitor.fair_location_special else ''),
         ('climate_compensation', exhibitor.climate_compensation),
         ('flyer', (exhibitor.flyer.url) if exhibitor.flyer else (MISSING_IMAGE if img_placeholder else None)),
-
         ('booths', [{
             'id': eib.booth.pk,
             'location': {

--- a/exhibitors/api.py
+++ b/exhibitors/api.py
@@ -43,6 +43,12 @@ def serialize_exhibitor(exhibitor, request):
         ('founded', exhibitor.catalogue_founded),
         ('groups',
          [{'id': group.pk, 'name': group.name} for group in exhibitor.company.groups.filter(fair=exhibitor.fair, allow_exhibitors=True)]),
+        ('fair_location', str(exhibitor.fair_location) if exhibitor.fair_location else ''), 
+        ('vyer_position', exhibitor.vyer_position if exhibitor.vyer_position else ''),
+        ('location_special', str(exhibitor.fair_location_special) if exhibitor.fair_location_special else ''),
+        ('climate_compensation', exhibitor.climate_compensation),
+        ('flyer', (exhibitor.flyer.url) if exhibitor.flyer else (MISSING_IMAGE if img_placeholder else None)),
+
         ('booths', [{
             'id': eib.booth.pk,
             'location': {


### PR DESCRIPTION
Updates to comply with task 091.

Every attribute has the same name as it does in the model.

- String representation of location (which includes parent location)
- Vyer map link (string)
- Location special (name only - string)
- Climate compensation boolean
- Link to exhibitor flyer (string)

Exhibitor competences (list of string) and exhibitor cities (string) has been added previously (as part of updating the matching API).

Please test when database has more content, so that for instance the map and flyer links work (currently only sends null).

Also solves task 160.