### PR TITLE
118 event email list

### DIFF
--- a/templates/events/emails.html
+++ b/templates/events/emails.html
@@ -1,1 +1,18 @@
-<h1>HEJ</h1>
+<h1>E-mail addresses</h1>
+<p>Make sure to use blind carbon copies (BCC) when sending e-mail messages to the people below.</p>
+
+<style type="text/css">
+	textarea
+	{
+		height: 200px;
+		width: 100%;
+		box-sizing: border-box;
+		font-size: 12pt;
+	}
+</style>
+
+<textarea>
+{% spaceless %}
+    {% for participant in participants|dictsort:"timestamp" %}{{ participant.assigned_name }} <{{ participant.assigned_email }}> {% if not forloop.last %}, {% endif %}{% endfor %}
+{% endspaceless %}
+</textarea>

--- a/templates/events/emails.html
+++ b/templates/events/emails.html
@@ -12,7 +12,5 @@
 </style>
 
 <textarea>
-{% spaceless %}
-    {% for participant in participants|dictsort:"timestamp" %}{{ participant.assigned_name }} <{{ participant.assigned_email }}> {% if not forloop.last %}, {% endif %}{% endfor %}
-{% endspaceless %}
+{% for participant in participants|dictsort:"timestamp" %}{{ participant.assigned_name }} <{{ participant.assigned_email }}> {% if not forloop.last %}, {% endif %}{% endfor %}
 </textarea>

--- a/templates/events/event_edit.html
+++ b/templates/events/event_edit.html
@@ -18,7 +18,7 @@
       ({{ event.team_set.count }})</a>
     </li>
 
-    <li role="presentation"><a href="#emails" aria-controls="emails" role="tab" data-toggle="tab">Emails</a></li>
+    <li role="presentation"><a href="#emails" aria-controls="emails" role="tab" data-toggle="tab">E-mails</a></li>
 
   </ul>
 
@@ -36,7 +36,7 @@
       {% include 'events/team_list.html' with teams=event.team_set.all event=event %}
     </div>
     <div role="tabpanel" class="tab-pane" id="emails">
-        {% include 'events/emails.html' %}
+        {% include 'events/emails.html' with participants=participants %}
     </div>
   </div>
 {% endblock %}


### PR DESCRIPTION
Adds an E-mails tab to the event page. The emails are presented in a textbox, similarly to the recruitment e-mails page. I'll post a screenshot in Asana since this is public and I don't wanna put anybody's e-mail address out there. :)