### PR TITLE
Deadlines for tickets creation/edit for companies

### DIFF
--- a/register/views.py
+++ b/register/views.py
@@ -586,7 +586,7 @@ def lunchtickets(request, company_pk):
 
 		if not company_contact: return redirect('anmalan:choose_company')
 
-	lunch_ticket_deadline = datetime.datetime(2019,11,12,23,59,0,0)
+	lunch_ticket_deadline = datetime.datetime(2019,10,12,23,59,0,0)
 	count_ordered = 0
 
 	for order in Order.objects.filter(purchasing_company = exhibitor.company, product = exhibitor.fair.product_lunch_ticket):
@@ -635,7 +635,7 @@ def lunchtickets_form(request, company_pk, lunch_ticket_pk = None):
 		if not company_contact: return redirect('anmalan:choose_company')
 
 	is_editable = company_contact is not None or request.user.has_perm('companies.base')
-	lunch_ticket_deadline = datetime.datetime(2019,11,12,23,59,00)
+	lunch_ticket_deadline = datetime.datetime(2019,10,12,23,59,00)
 	if timezone.now() > lunch_ticket_deadline:
 		is_editable = False
 
@@ -695,7 +695,7 @@ def banquet(request, company_pk):
 
 		if not company_contact: return redirect('anmalan:choose_company')
 
-	banquet_ticket_deadline = datetime.datetime(2019,11,7,23,59,00)
+	banquet_ticket_deadline = datetime.datetime(2019,10,7,23,59,00)
 	count_ordered = 0
 
 	for banquet in Banquet.objects.filter(fair = fair).exclude(product = None):
@@ -745,7 +745,7 @@ def banquet_form(request, company_pk, banquet_participant_pk = None):
 		if not company_contact: return redirect('anmalan:choose_company')
 
 	is_editable = company_contact is not None or request.user.has_perm('companies.base')
-	banquet_ticket_deadline = datetime.datetime(2019,11,7,23,59,00)
+	banquet_ticket_deadline = datetime.datetime(2019,10,7,23,59,00)
 	if timezone.now() > banquet_ticket_deadline:
 		is_editable = False
 

--- a/register/views.py
+++ b/register/views.py
@@ -1,5 +1,6 @@
 import requests as r
 import json
+import datetime
 
 from django.shortcuts import render, get_object_or_404, redirect, HttpResponseRedirect
 from django.urls import reverse
@@ -585,6 +586,7 @@ def lunchtickets(request, company_pk):
 
 		if not company_contact: return redirect('anmalan:choose_company')
 
+	lunch_ticket_deadline = datetime.datetime(2019,11,12,23,59,0,0)
 	count_ordered = 0
 
 	for order in Order.objects.filter(purchasing_company = exhibitor.company, product = exhibitor.fair.product_lunch_ticket):
@@ -610,6 +612,8 @@ def lunchtickets(request, company_pk):
 		'exhibitor': exhibitor,
 		'days': days,
 		'can_create': count_ordered > count_created,
+		'past_deadline': timezone.now() > lunch_ticket_deadline,
+		'lunch_ticket_deadline': lunch_ticket_deadline,
 		'count_ordered': count_ordered,
 		'count_created': count_created
 	})
@@ -631,6 +635,9 @@ def lunchtickets_form(request, company_pk, lunch_ticket_pk = None):
 		if not company_contact: return redirect('anmalan:choose_company')
 
 	is_editable = company_contact is not None or request.user.has_perm('companies.base')
+	lunch_ticket_deadline = datetime.datetime(2019,11,12,23,59,00)
+	if timezone.now() > lunch_ticket_deadline:
+		is_editable = False
 
 	lunch_ticket = get_object_or_404(LunchTicket, pk = lunch_ticket_pk, company = company) if lunch_ticket_pk is not None else None
 
@@ -688,6 +695,7 @@ def banquet(request, company_pk):
 
 		if not company_contact: return redirect('anmalan:choose_company')
 
+	banquet_ticket_deadline = datetime.datetime(2019,11,7,23,59,00)
 	count_ordered = 0
 
 	for banquet in Banquet.objects.filter(fair = fair).exclude(product = None):
@@ -714,6 +722,8 @@ def banquet(request, company_pk):
 		'exhibitor': exhibitor,
 		'banquets': banquets,
 		'can_create': count_ordered > count_created,
+		'past_deadline': timezone.now() > banquet_ticket_deadline,
+		'banquet_ticket_deadline': banquet_ticket_deadline,
 		'count_ordered': count_ordered,
 		'count_created': count_created
 	})
@@ -735,6 +745,9 @@ def banquet_form(request, company_pk, banquet_participant_pk = None):
 		if not company_contact: return redirect('anmalan:choose_company')
 
 	is_editable = company_contact is not None or request.user.has_perm('companies.base')
+	banquet_ticket_deadline = datetime.datetime(2019,11,7,23,59,00)
+	if timezone.now() > banquet_ticket_deadline:
+		is_editable = False
 
 	banquet_participant = get_object_or_404(BanquetParticipant, pk = banquet_participant_pk, company = company) if banquet_participant_pk is not None else None
 
@@ -788,7 +801,7 @@ def banquet_form(request, company_pk, banquet_participant_pk = None):
 		'is_editable': is_editable
 	})
 
-
+# Has not been used in 2019 or the years before. Would be nice to implement an events tab where companies can add participants to events (mainly for Armada Run).
 def events(request, company_pk):
 	if not request.user.is_authenticated(): return redirect('anmalan:logout')
 

--- a/register/views.py
+++ b/register/views.py
@@ -586,7 +586,7 @@ def lunchtickets(request, company_pk):
 
 		if not company_contact: return redirect('anmalan:choose_company')
 
-	lunch_ticket_deadline = datetime.datetime(2019,10,12,23,59,0,0)
+	lunch_ticket_deadline = datetime.datetime(2019,11,12,23,59,0,0)
 	count_ordered = 0
 
 	for order in Order.objects.filter(purchasing_company = exhibitor.company, product = exhibitor.fair.product_lunch_ticket):
@@ -635,7 +635,7 @@ def lunchtickets_form(request, company_pk, lunch_ticket_pk = None):
 		if not company_contact: return redirect('anmalan:choose_company')
 
 	is_editable = company_contact is not None or request.user.has_perm('companies.base')
-	lunch_ticket_deadline = datetime.datetime(2019,10,12,23,59,00)
+	lunch_ticket_deadline = datetime.datetime(2019,11,12,23,59,0,0)
 	if timezone.now() > lunch_ticket_deadline:
 		is_editable = False
 
@@ -695,7 +695,7 @@ def banquet(request, company_pk):
 
 		if not company_contact: return redirect('anmalan:choose_company')
 
-	banquet_ticket_deadline = datetime.datetime(2019,10,7,23,59,00)
+	banquet_ticket_deadline = datetime.datetime(2019,11,7,23,59,00)
 	count_ordered = 0
 
 	for banquet in Banquet.objects.filter(fair = fair).exclude(product = None):
@@ -745,7 +745,7 @@ def banquet_form(request, company_pk, banquet_participant_pk = None):
 		if not company_contact: return redirect('anmalan:choose_company')
 
 	is_editable = company_contact is not None or request.user.has_perm('companies.base')
-	banquet_ticket_deadline = datetime.datetime(2019,10,7,23,59,00)
+	banquet_ticket_deadline = datetime.datetime(2019,11,7,23,59,00)
 	if timezone.now() > banquet_ticket_deadline:
 		is_editable = False
 

--- a/templates/register/inside/banquet.html
+++ b/templates/register/inside/banquet.html
@@ -8,7 +8,7 @@
 
 {% block content %}
 	<h1>Banquet</h1>
-	<p>Here you can create and edit your ordered banquet tickets.</p>
+	<p>Here you can create and edit your ordered banquet tickets. You can create and edit tickets until {{ banquet_ticket_deadline|date:"F j, H: I" }}</p>
 
 	<ul class="no-bullets">
 		<li><span class="information_label">Ordered banquet tickets:</span> {{ count_ordered }}</li>

--- a/templates/register/inside/banquet.html
+++ b/templates/register/inside/banquet.html
@@ -8,14 +8,14 @@
 
 {% block content %}
 	<h1>Banquet</h1>
-	<p>Here you can create and edit your ordered banquet tickets. You can create and edit tickets until {{ banquet_ticket_deadline|date:"F j, H: I" }}</p>
+	<p>Here you can create and edit your ordered banquet tickets. You can create and edit tickets until {{ banquet_ticket_deadline|date:"F j, H:i" }}.</p>
 
 	<ul class="no-bullets">
 		<li><span class="information_label">Ordered banquet tickets:</span> {{ count_ordered }}</li>
 		<li><span class="information_label">Created banquet tickets:</span> {{ count_created }}</li>
 	</ul>
 
-	{% if can_create %}
+	{% if can_create and not past_deadline %}
 		<h3>Create new banquet ticket</h3>
 		<p>You have ordered more banquet tickets than you have created.</p>
 		<p><a class="btn btn-armada-green" href="{% url 'anmalan:banquet_new' company.pk %}">Create new banquet ticket</a></p>
@@ -33,7 +33,7 @@
 
 			{% for banquet_ticket in banquet.banquet_tickets %}
 				<div class="banquet_ticket">
-					<a class="btn btn-armada-green" style="float: right;" href="{% url 'anmalan:banquet_edit' company.pk banquet_ticket.pk %}">Edit</a>
+					{% if not past_deadline %}<a class="btn btn-armada-green" style="float: right;" href="{% url 'anmalan:banquet_edit' company.pk banquet_ticket.pk %}">Edit</a>{% endif %}
 
 					<ul class="no-bullets">
 						<li><span class="information_label">Name:</span> {{ banquet_ticket.name }}</li>

--- a/templates/register/inside/lunchtickets.html
+++ b/templates/register/inside/lunchtickets.html
@@ -8,7 +8,7 @@
 
 {% block content %}
 	<h1>Lunch tickets</h1>
-	<p>Here you can create and edit your ordered lunch tickets. You can create and edit tickets until <span style="font-weight: 700;">{{ lunch_ticket_deadline|date:"F j, H: I" }}</span>.</p>
+	<p>Here you can create and edit your ordered lunch tickets. You can create and edit tickets until {{ lunch_ticket_deadline|date:"F j, H:i" }}.</p>
 
 	<ul class="no-bullets">
 		<li><span class="information_label">Ordered lunch tickets:</span> {{ count_ordered }}</li>

--- a/templates/register/inside/lunchtickets.html
+++ b/templates/register/inside/lunchtickets.html
@@ -8,14 +8,14 @@
 
 {% block content %}
 	<h1>Lunch tickets</h1>
-	<p>Here you can create and edit your ordered lunch tickets.</p>
+	<p>Here you can create and edit your ordered lunch tickets. You can create and edit tickets until <span style="font-weight: 700;">{{ lunch_ticket_deadline|date:"F j, H: I" }}</span>.</p>
 
 	<ul class="no-bullets">
 		<li><span class="information_label">Ordered lunch tickets:</span> {{ count_ordered }}</li>
 		<li><span class="information_label">Created lunch tickets:</span> {{ count_created }}</li>
 	</ul>
 
-	{% if can_create %}
+	{% if can_create and not past_deadline %}
 		<h3>Create new lunch ticket</h3>
 		<p>You have ordered more lunch tickets than you have created.</p>
 		<p><a class="btn btn-armada-green" href="{% url 'anmalan:lunchtickets_new' company.pk %}">Create new lunch ticket</a></p>
@@ -27,7 +27,7 @@
 		{% if day.lunch_tickets %}
 			{% for lunch_ticket in day.lunch_tickets %}
 				<div class="lunch_ticket">
-					<a class="btn btn-armada-green" style="float: right;" href="{% url 'anmalan:lunchtickets_edit' company.pk lunch_ticket.pk %}">Edit</a>
+					{% if not past_deadline %}<a class="btn btn-armada-green" style="float: right;" href="{% url 'anmalan:lunchtickets_edit' company.pk lunch_ticket.pk %}">Edit</a>{% endif %}
 
 					<ul class="no-bullets">
 						<li><span class="information_label">E-mail address:</span> {{ lunch_ticket.email_address }}</li>


### PR DESCRIPTION
Added functionality to set a deadline for when lunch tickets and banquet tickets can be created/edited on the registration page for companies. Right now this is hardcoded in the register views.py but the times should preferrably be added as fields to the fair object. This will be implemented at a later time since it had som chain issues to fix connected to adding fields to the fair model.