### PR TITLE
Added ability to show check-in comments in exhibitor overview list

### DIFF
--- a/exhibitors/models.py
+++ b/exhibitors/models.py
@@ -261,6 +261,7 @@ class ExhibitorView(models.Model):
 		'count_lunch_tickets': 'Lunch tickets',
 		'count_banquet_tickets': 'Banquet tickets',
 		'check_in_timestamp': 'Check in',
+		'check_in_comment': 'Check in comment',
 		'booths': 'Booths',
         'fair_location': 'Fair location',
         'fair_location_special': 'Special Location'

--- a/exhibitors/views.py
+++ b/exhibitors/views.py
@@ -99,6 +99,7 @@ def exhibitors(request, year, template_name='exhibitors/exhibitors.html'):
             if choice == 'electricity_equipment': value = e.electricity_equipment
             if choice == 'booth_height': value = e.booth_height
             if choice == 'check_in_timestamp': value = e.check_in_timestamp
+            if choice == 'check_in_comment': value = e.check_in_comment
             if choice == 'fair_location': value = e.fair_location
             if choice == 'fair_location_special': value = e.fair_location_special
 

--- a/templates/exhibitors/exhibitors.html
+++ b/templates/exhibitors/exhibitors.html
@@ -11,39 +11,39 @@
 	<ol class="breadcrumb">
 		<li class="active">Exhibitors</li>
 	</ol>
-	
+
 	<h1>Exhibitors ({{ exhibitors|length }})</h1>
-	
+
 	<p>
 		{% if perms.exhibitors.modify_booths %}<a href="{% url 'booths' fair.year %}" class="btn btn-default">Booths</a>{% endif %}
 		<a href="{% url 'edit_view' fair.year %}" class="btn btn-default">Edit view</a>
 		{% if perms.exhibitors.create %}<a href="{% url 'create' fair.year %}" class="btn btn-default">Create exhibitor</a>{% endif %}
 		<a href="{% url 'export' fair.year %}" class="btn btn-default">Export exhibitors</a>
 	</p>
-	
+
 	<form method="post">
 		{% csrf_token %}
 		{{ form | crispy }}
 		<input class="btn btn-primary" type="submit" value="Refine search" />
 	</form>
-	
+
 	<div class="table-responsive">
 		<table class="table" id="exhibitor_table">
 			<thead>
 			<tr>
 				<th>Exhibitor</th>
-				
+
 				{% for field in fields %}
 					<th style="white-space: nowrap;">{% get_field_name field %}</th>
 				{% endfor %}
 				</tr>
 			</thead>
-			
+
 			<tbody>
 				{% for exhibitor in exhibitors %}
 					<tr>
 						<td style="white-space: nowrap;"><a href="{% url 'exhibitor' fair.year exhibitor.id %}">{{ exhibitor.name }}</a></td>
-						
+
 						{% for field in exhibitor.fields %}
 							{% if field.field == 'contact_persons' %}
 								<td style="white-space: nowrap;">
@@ -80,6 +80,8 @@
 							{% elif field.field == 'check_in_timestamp' %}
 								{% if field.value is None %}<td class="bg-danger"></td>
 								{% else %}<td style="white-space: nowrap;"><span style="display: none;">{{ field.value|date:"U" }}</span>{{ field.value }}</td>{% endif %}
+							{% elif field.field == 'check_in_comment' %}
+								<td style="white-space: nowrap;">{% if field.value %}{{field.value}}{% endif %}</td>
 							{% elif field.field == 'booths' %}
 								<td style="white-space: nowrap;">
 									<ul class="list-unstyled">
@@ -111,4 +113,3 @@
 		});
 	</script>
 {% endblock %}
-


### PR DESCRIPTION
In addition to for example check in time one can now also select to view the check in comments already in the list of exhibitors - previously the comment was only shown in the view of a single exhibitor.