### PR TITLE
Let the frontend choose to get an exhibitor list from another year

### DIFF
--- a/exhibitors/api.py
+++ b/exhibitors/api.py
@@ -67,9 +67,11 @@ def serialize_exhibitor(exhibitor, request):
 
 @cache_page(60 * 5)
 def exhibitors(request):
+    f = Fair.objects.get(year = request.GET['year']) if 'year' in request.GET else Fair.objects.get(current = true)
+
     data = []
 
-    for exhibitor in Exhibitor.objects.filter(fair=Fair.objects.get(current = True)):
+    for exhibitor in Exhibitor.objects.filter(fair=f):
         data.append(serialize_exhibitor(exhibitor, request))
 
     return JsonResponse(data, safe=False)


### PR DESCRIPTION
This allows you to call `/api/exhibitors` either in the way you've always done it, to get the exhibitors for the current year, or with an additional `year` query string parameter, to get the exhibitors from another year, e.g. `/api/exhibitors?year=2019`. Could be useful to somebody... Perhaps...!