### PR TITLE
Don't overwrite the fair variable with a new reference

### DIFF
--- a/companies/views.py
+++ b/companies/views.py
@@ -388,10 +388,10 @@ def companies_view(request, year, pk):
 
 	fairs = []
 
-	for fair in Fair.objects.all():
+	for f in Fair.objects.all():
 		fairs.append({
-			'fair': fair,
-			'exhibitor': Exhibitor.objects.filter(fair = fair, company = company).count() == 1
+			'fair': f,
+			'exhibitor': Exhibitor.objects.filter(fair = f, company = company).count() == 1
 		})
 
 	return render(request, 'companies/companies_view.html',


### PR DESCRIPTION
The for loop that goes through all fairs before sending them to the template rendering function had a variable with the name `fair`, which caused the function parameter `fair` to be overwritten. This could lead to an unexpected fair showing up in the template, depending on which fair the for loop handled in its last iteration.