### PR TITLE
078 - IR /CR - Placement_wish '----' choice

### DIFF
--- a/companies/forms.py
+++ b/companies/forms.py
@@ -1,12 +1,13 @@
 import re, datetime
 
-from django.forms import ModelForm, HiddenInput, BaseModelFormSet
+from django.forms import ModelForm, HiddenInput, BaseModelFormSet, ModelChoiceField
 from django.contrib.auth.forms import UserCreationForm
 from django.contrib.auth.models import User
 from django import forms
 
 from register.models import SignupContract
 from accounting.models import Product, Order
+from people.models import Language
 from .models import Company, CompanyAddress, CompanyCustomer, CompanyCustomerResponsible, CompanyContact, CompanyCustomerComment, Group
 from fair.models import Fair
 
@@ -145,6 +146,9 @@ def fix_phone_number(n):
 
 # form to be used for intital registration, excludes user, company, active, confirmed as the contact person should not see this
 class InitialCompanyContactForm(ModelForm):
+	# Set "None" to be displayed as "No Preference"
+	preferred_language = ModelChoiceField(queryset=Language.objects.all(), empty_label=Language.EMPTY_DISPLAY_VALUE)
+
 	def clean(self):
 		super(InitialCompanyContactForm, self).clean()
 
@@ -184,6 +188,9 @@ class InitialCompanyContactForm(ModelForm):
 
 
 class CompanyContactForm(ModelForm):
+	# Set "None" to be displayed as "No Preference"
+	preferred_language = ModelChoiceField(queryset=Language.objects.all(), empty_label=Language.EMPTY_DISPLAY_VALUE)
+
 	def clean(self):
 		super(CompanyContactForm, self).clean()
 
@@ -229,6 +236,9 @@ class UserForm(UserCreationForm):
 
 
 class CreateCompanyContactForm(ModelForm):
+	# Set "None" to be displayed as "No Preference"
+	preferred_language = ModelChoiceField(queryset=Language.objects.all(), empty_label=Language.EMPTY_DISPLAY_VALUE)
+
 	def clean(self):
 		super(CreateCompanyContactForm, self).clean()
 

--- a/people/models.py
+++ b/people/models.py
@@ -5,6 +5,9 @@ from django.db import models
 from lib.image import UploadToDirUUID, UploadToDir, update_image_field
 
 class Language(models.Model):
+	# Displayed in place of None/null
+	EMPTY_DISPLAY_VALUE = "No preference"
+
 	name = models.CharField(max_length = 100)
 	short = models.CharField(max_length = 100)
 


### PR DESCRIPTION
All three forms for company contacts (in companies/forms.py) have had their empty_label set to a constant "No preference" found in the Language model found in peoples/models.py, displayed instead of "----" when the field is null.

Initially attempted to solve by changing the __str__ function of the Language model, but this would not have changed the forms when a company contact is created, only when the language of an existing company contact is retrieved.