### PR TITLE
078 - IR /CR - Placement_wish '----' choice

### DIFF
--- a/exhibitors/models.py
+++ b/exhibitors/models.py
@@ -134,6 +134,7 @@ class Exhibitor(models.Model):
     deadline_complete_registration = models.DateTimeField(blank = True, null = True, verbose_name = 'Deviating deadline for complete registration')
 
     placement_wishes = [
+        (None, 'No preference'),
         ('MIXED', 'Mixed with companies from other industries'),
         ('SIMILAR', 'Next to similar companies'),
     ]


### PR DESCRIPTION
Changed the placement_wish field to say "No preference" instead of "----" when the value is None. Simple change of choices attribute in exhibitors/models.py.

**Full testing steps from untouched ais:**

- Login on admin
- /admin/register/signupcontract/add/ create initial+complete for Armada 2020
- /admin/fair/fair/5/change/ set initial end date after today, complete start date far into future, complete end date even farther into future
- Logout from admin
- Login on salescontact1 at /register
- Sign the contract
- Logout from salescontact1
- Login on admin
- /admin/exhibitors/exhibitor/add/ add Sales Company 1 as an exhibitor to Armada 2020
- /admin/fair/fair/5/change/ set initial end date a few days back, set complete start day to yesterday
- Logout from admin
- Login on salescontact1 at /register
- Expand "Logistics and booth details", scroll down to "Placement wish"

To confirm the difference, comment out the edited line "(None, 'No preference')" in exhibitors/models.py and reload the page to see the version with "----".