### PR TITLE
119 - Events - add contact email

### DIFF
--- a/events/serializers.py
+++ b/events/serializers.py
@@ -22,6 +22,7 @@ def event(event, request):
         'image_url': request.build_absolute_uri(event.picture.url) if event.picture else None,
         'fee': event.fee_s,
         'registration_required': True,
+        'contact_person': {'name': event.contact_person.get_full_name(), 'email': event.contact_person.email},
         'external_event_link': event.external_event_link,
         'signup_questions': [signup_question(question) for question in event.signupquestion_set.all()],
         'signup_link': signup_url,

--- a/events/static/js/signup/components/Header.js
+++ b/events/static/js/signup/components/Header.js
@@ -22,6 +22,16 @@ class Header extends Component {
             {event.description}
           </Typography>
           <Grid container spacing={16}>
+          {event.contact_person && (
+              <Grid item sm={12}>
+                <Typography variant="caption" gutterBottom>
+                  Contact
+                </Typography>
+                <Typography>
+                  {event.contact_person.name} - {event.contact_person.email}
+                </Typography>
+              </Grid>
+            )}
             {event.location && (
                 <Grid item sm={6}>
                   <Typography variant="caption" gutterBottom>


### PR DESCRIPTION
Added contact person name and email to signup page of events.

**Full testing steps from untouched ais:**

- Login as admin
- /fairs/2019/events Click on one event
- Add /signup to the end of the url
- If it didn't work, try with /fairs/2019/events/31/signup (some events have no signup page)
- "Contact" should now be visible with a name and an email above the other fields

Potential problem - always showing the kth-email, should maybe show an armada email?