### PR TITLE
Banquet: Fix a working QR-code for non-AIS people's tickets

### DIFF
--- a/templates/banquet/manage_participant.html
+++ b/templates/banquet/manage_participant.html
@@ -45,13 +45,9 @@
 
 	<h2>Ticket link</h2>
 	{% if banquet.background %}
-	{% if participant.seat %}
 	<p>Give the following link to the participant.</p>
 	
 	<input type="text" value="https://ais.armada.nu{% url 'banquet_participant_display' participant.token %}" />
-	{% else %}
-	<p>Before the generated link for a participant can work, they must be assigned a seat.</p>
-	{% endif %}
 	{% else %}
 	<p>Before the generated links can work, a background image needs to be uploaded (ask an IT admin) for the banquet.</p>
 	{% endif %}

--- a/templates/banquet/manage_participant.html
+++ b/templates/banquet/manage_participant.html
@@ -44,7 +44,15 @@
 	</p>
 
 	<h2>Ticket link</h2>
+	{% if banquet.background %}
+	{% if participant.seat %}
 	<p>Give the following link to the participant.</p>
-
+	
 	<input type="text" value="https://ais.armada.nu{% url 'banquet_participant_display' participant.token %}" />
+	{% else %}
+	<p>Before the generated link for a participant can work, they must be assigned a seat.</p>
+	{% endif %}
+	{% else %}
+	<p>Before the generated links can work, a background image needs to be uploaded (ask an IT admin) for the banquet.</p>
+	{% endif %}
 {% endblock %}


### PR DESCRIPTION
The QR-codes were working all along, but required a background image to be uploaded for the corresponding Banquet object. Additionally, a participant's link would not work if they had not been assigned a seat. To prevent these links from being opened in the future (prompting a 500 Server Error), the link is hidden until these two conditions are true and instead a text is shown explaining why the link is not.

**Full testing steps from untouched ais:**

0. ./dev-runserver.sh (sudo may or may not be needed)
1. Login to the ais as admin (on localhost, duh)
2. In the admin view, under Banquet -> Banquets, create a new Banquet belonging to the Armada 2020 fair. Add a name, a date, and a time.
3. In the admin view, under Banquet -> Participants, create a new participant. Select the banquet you just created, add a name and skip the rest of the parameters that aren't pre-filled.
4. Go to the regular ais, 'Banquet' -> 'Participants' -> 'Details'. *Under 'Ticket link' it should explain that a background image needs to be uploaded to the banquet.*
5. Back in the admin view, edit the banquet you created, upload an image (any .jpg for instance) to the 'Background' parameter.
6. On the same page as in step 4, *under 'Ticket link' it should now instead explain that the participant needs a seat assigned before the link will appear/work.
7. In the admin view, add a Table and then a seat to that table under the Banquet menu. Choose any names. The parameters top and left of the seat refer to its pixel position on the background image, so make sure they're not larger than the height/width of the background image you uploaded.
8. Finding the participant in the same way as in step 4, now choose "Edit participant" and select the seat you just created, then save the participant (you will be prompted for an email-address at which point you can add 'test@gmail.com' or similar).
9. View the participant's details like in step 4 one last time. This time, under 'Ticket link' it should say 'Give the following link to the participant.' followed by an input box with a link in it. Neither of these should have been visible prior to this point. Please note that the link will not work as it's using a token for a participant you've created locally while the urls always point to the live server of the "real" ais.