### PR TITLE
Banquet: Ticket payment status

### DIFF
--- a/banquet/views.py
+++ b/banquet/views.py
@@ -780,6 +780,7 @@ def invitation(request, year, token):
                 else: # retrieve existing payment intent
                     intent = stripe.PaymentIntent.retrieve(invitation.participant.charge_stripe)
 
+                request.session['event'] = 'Banquet'
                 request.session['intent'] = intent
                 request.session['invitation_token'] = token
                 request.session['url_path'] = '/fairs/' + str(fair.year) + '/banquet/invitation/' + token
@@ -895,6 +896,7 @@ def external_invitation(request, token):
                 else: # retrieve existing payment intent
                     intent = stripe.PaymentIntent.retrieve(invitation.participant.charge_stripe)
 
+                request.session['event'] = 'Banquet'
                 request.session['intent'] = intent
                 request.session['invitation_token'] = token
                 request.session['url_path'] = '../banquet/' + token


### PR DESCRIPTION
**Summary**
Some of the invites pay for their tickets to the banquet, the purchase goes through but the status in the ais still says "not paid". The status needed to be changed manually.

**Expected results**
Status should be updated automatically.

**Previous results**
From the user perspective, when a banquet ticket is paid either using an external or internal invitation, the payment finishes successfully. However, the status of the invitation remains as 'not paid' and the redirection after payment does not work properly.
From the admin perspective, during the payment a new participant is created and linked to the corresponding invitation. However, the 'has paid' status of the participant is not updated.

**Steps to reproduce**
_In ais:_
1. Create a Banquet 2020 if it does not exist.
2. Create an Invitation group for the banquet (e.g Primary 2020) if it does not exist.
3. Create a test user if it does not exist.

_In the UI signed in as admin:_
4. Go to Banquet tab, select Banquet 2020 -> Invitations -> New invitation
5. Fill 'Name' and 'Email address' with the ones of the test user. Insert a Price > 0 and save invitation.

_In ais:_
6. Go to Invitations and select the new invitation (it should show the name of the test user)
7. Select the test user in the dropdown field 'User' and save the invitation.

_In the UI signed in as test user:_
8. Go to Banquet tab and select the invitation.
9. Add a phone number and click on 'Proceed to payment'.
10. Add a cardholder's name and fill the card details with 4242 4242 4242 4242   _MM/YY:_ 04/24    _CVC_ 242  _ZIP_ 42424
11. Click on 'Submit payment'.

A transient green alert should show up with the message 'Payment succeeded, Thank you'. Then it should redirect to the Banquet page. In this page, 'Invitation status' should be 'You are going' and a green message with the text 'We have received your payment of SEK {amount}.' should appear under the 'If you are attending' section.

Alternatively, the payment can be done using the invitation link created in step 5. This link should be modified to match http://localhost:{port}/ The same behavior is expected once the payment is processed.