### PR TITLE
Get user info from KTH Profiles API

### DIFF
--- a/lib/CAS_callback.py
+++ b/lib/CAS_callback.py
@@ -6,24 +6,24 @@ from django.http import HttpResponseRedirect
 
 def callback(tree):
 	kth_id = tree[0][0].text
+
 	logging.info('KTH-ID: %s trying to login' %kth_id)
 	
 	user, user_created = User.objects.get_or_create(username = kth_id)
-	
-	ldap = lookup_user(kth_id)
-	
-	if ldap is not None and Profile.objects.filter(user = user, kth_synchronize = False).count() == 0:
-		if ldap['first_name'] is not None:
-			user.first_name = ldap['first_name']
+	user_info = lookup_user(kth_id)
+
+	if user_info is not None and Profile.objects.filter(user = user, kth_synchronize = False).count() == 0:
+		if user_info['first_name'] is not None:
+			user.first_name = user_info['first_name']
 		
-		if ldap['last_name'] is not None:
-			user.last_name = ldap['last_name']
+		if user_info['last_name'] is not None:
+			user.last_name = user_info['last_name']
 		
-		if ldap['email'] is not None and (user.email is None or len(user.email) == 0 or user.email.endswith('@kth.se')):
-			user.email = ldap['email']
-		
+		if user_info['email'] is not None and (user.email is None or len(user.email) == 0 or user.email.endswith('@kth.se')):
+			user.email = user_info['email']
+
 		user.save()
-	
+
 	profile = Profile.objects.filter(user = user).first()
-	
-	if profile is None: Profile(user = user, no_dietary_restrictions = False).save()
+	if profile is None:
+		Profile(user = user, no_dietary_restrictions = False).save()

--- a/lib/KTH_Catalog.py
+++ b/lib/KTH_Catalog.py
@@ -1,31 +1,68 @@
 import subprocess, base64
+import requests
 
 def lookup_user(kth_id):
+	"""
+	Lookup a user by KTH-ID. First, an attempt to connect to KTH directory using LDAP protocol is made.
+	If the first attempt fails, a second attempt is made using KTH Profiles API.
+
+	Params:
+		`kth_id`: User's KTH-ID (username)
+
+	Returns:
+		`user_info`: User information containing the email, first name and last name if available.
+	"""
+
+	# Try ldap protocol to get user details
+	user_dict = lookup_user_with_ldap(kth_id)
+
+	# If ldap does not succeed, try  api
+	if user_dict is None:
+		user_dict = lookup_user_with_api(kth_id)
+	
+	return user_dict
+
+def lookup_user_with_ldap(kth_id):
 	try:
 		raw = subprocess.check_output(["ssh", "armada@cloud.armada.nu", "ldapsearch -x -h ldap.kth.se -s sub -b 'ou=Addressbook,dc=kth,dc=se' 'ugKthid=" + kth_id + "'"], timeout = 3).decode("utf-8").split("\n")
-	
 	except:
 		print('failed to connect to LDAP')
 		return None
 	
-	email = None
-	first_name = None
-	last_name = None
-	
+	user_info = dict(email=None, first_name=None, last_name=None)
+
 	for line in raw:
 		if line.startswith("mail: "):
-			email = line[6:].strip()
+			user_info['email'] = line[6:].strip()
 			
 		if line.startswith("givenName: "):
-			first_name = line[11:].strip()
+			user_info['first_name'] = line[11:].strip()
 			
 		if line.startswith("givenName:: "):
-			first_name = base64.b64decode(line[12:].strip())
+			user_info['first_name'] = base64.b64decode(line[12:].strip())
 			
 		if line.startswith("sn: "):
-			last_name = line[4:].strip()
+			user_info['last_name'] = line[4:].strip()
 			
 		if line.startswith("sn:: "):
-			last_name = base64.b64decode(line[5:].strip())
+			user_info['last_name'] = base64.b64decode(line[5:].strip())
+
+	return user_info
+
+def lookup_user_with_api(kth_id):
+	# KTH Profiles API - Swagger: https://api.kth.se/api/profile/swagger/?url=/api/profile/swagger.json#/v1.1/getPublicProfile_v11
+	base_uri = "https://api.kth.se/api/profile/1.1/"
+
+	uri = base_uri + kth_id
+	response = requests.get(uri)
 	
-	return dict(email = email, first_name = first_name, last_name = last_name)
+	if response.status_code // 100 != 2 or len(response.content) == 0:
+		print('failed to connect to KTH Profiles API')
+		return None
+
+	try: 
+		json = response.json()
+	except:
+		return None
+
+	return dict(email=json.get('email'), first_name=json.get('givenName'), last_name=json.get('familyName'))


### PR DESCRIPTION
**Problem**
Some users appear with empty email, first name and last name although they signed in using their KTH account.

**Expected results**
User information should be retrieved from KTH if they sign in with their KTH account and the kth_synchronize field equals to True. Also, existing empty info should be filled up once the user signs in.

**Background**
Each time a user sign in with their KTH account, an attempt to get the updated user information from KTH is made using LDAP. For some reason, it seems that LDAP not always work and, therefore, the user information (i.e email, first name and last name) remains empty.

**Proposal**
This PR adds a second attempt to get the user information using the public [KTH Profile API](https://api.kth.se/api/profile/swagger/?url=/api/profile/swagger.json#/v1.1) in case the first attempt using LDAP does not succeed.

**Steps to reproduce**
In both attempts, the user's KTH-ID (i.e username) is used to get the user's personal details. This id is received via a _callback_ endpoint in our backend that is invoked by KTH website once the user signs in successfully. Since KTH sign-in cannot be currently reproduced during local development, the callback endpoint was manually invoked for testing purposes so far.

_To reproduce in production:_
_Users must have kth_synchronize field set to True_
- When a new user signs in using KTH account, the email, first name and last name should be added to his new armada user.
- When an existing user with empty info signs in using KTH account, this info should be filled automatically.
- When an existing user signs in using KTH account, their info should be updated according to current KTH account.

_To reproduce in dev:_
_Users must have kth_synchronize field set to True_
1. Delete or modify any user email, first name and last name in http://localhost:8080/admin/auth/users
1. Replace [Line 8](https://github.com/armada-ths/ais/blob/master/lib/CAS_callback.py#L8) with `kth_id = tree.GET.get('kth_id')`
2. Replace [Line 6](https://github.com/armada-ths/ais/blob/84de93ae3f6dd765bdbc6663f68e15972337fea3/ais/local/urls.py#L6) with `url(r'^login/', CAS_callback.callback, name='login')` and add `from lib import CAS_callback` at the top.
3. Send a POST request to `http://localhost:8080/login?kth_id=<kth_id>` where <kth_id> is the username of the user 'signing in'.
4. User info in http://localhost:8080/admin/auth/users should be updated. 

 