### PR TITLE
removed hyperlink from base.html

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -96,8 +96,7 @@
 <div class="container">
   <hr/>
 
-  <p class="text-muted">Questions or feedback? Visit <a href="https://thsarmadaot19.slack.com/messages/CM923LGLA"
-                                                        target="_blank">#it-support  on Slack</a> or send an electronic letter to <a
+  <p class="text-muted">Questions or feedback? Visit #it-support on Slack or send an electronic letter to <a
       href="mailto:support@armada.nu">support@armada.nu</a>.</p>
 </div>
 


### PR DESCRIPTION
Removed the hyperlink to Slack channel the bottom of the AIS page.