### PR TITLE
701: Refactor: Event tab, (remove react ?)

### DIFF
--- a/dev-runserver.sh
+++ b/dev-runserver.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
 cd /vagrant
+npm run build &&
 npm run watch &
 /vagrant/ais_venv/bin/python manage.py runserver 0.0.0.0:8080 --settings local_settings

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,5 +18,5 @@ django-markupfield
 markdown
 slackclient==1.3.1
 stripe
-django-webpack-loader
+django-webpack-loader==0.7.0
 postgis

--- a/shared_js/config/webpack.config.js
+++ b/shared_js/config/webpack.config.js
@@ -21,6 +21,7 @@ const config = {
 
   plugins: [
     new BundleTracker({
+      path: path.resolve(__dirname, '../../'),
       filename: './webpack-stats.js'
     }),
     new CleanWebpackPlugin([path.resolve('./ais_static/bundles/')], {


### PR DESCRIPTION
#701 

- The changes made are currently working locally on my linux machine but haven't been able to test it out in vagrant or others devices.
- The changes made are only downgrading the dependencies. 
- I suspect that we will need to do some changes in how we build the webpack as of now we only watch it but never build it(I think, haven't look it through when it comes to vagrant)
- I also suspect that vagrant are using an old version of node and npm which can be the cause of newer problem. **I will need to know which version of `nodejs` and `npm` we have on the AIS server** @rrudling .