### PR TITLE
#719: Fix: Invite friends to the after party

### DIFF
--- a/banquet/views.py
+++ b/banquet/views.py
@@ -407,7 +407,7 @@ def dashboard(request, year):
         'after_party_invites': {
             'invites': after_party_invites,
             'form': invite_form,
-            'show': invite_permission and False,
+            'show': invite_permission and invitation_period,
             'show_form': len(after_party_invites) < max_invites, # Can be used in the template to check whether invitation form should be presented
             'left': max_invites - len(after_party_invites)
         }


### PR DESCRIPTION
There were hard-coded changes that closed the after-party-invitations. I shall work now.

You shall be able to see a invite screen.
![image](https://user-images.githubusercontent.com/25460850/141276645-a99e555a-2bb2-44f6-9415-3f4326bc4994.png)
