### PR TITLE
fix(register): Fetch the fair from the current timezone year

### DIFF
--- a/register/views.py
+++ b/register/views.py
@@ -145,7 +145,9 @@ def form(request, company_pk):
     if not request.user.is_authenticated: return redirect('anmalan:logout')
 
     company = get_object_or_404(Company, pk=company_pk)
-    fair = Fair.objects.filter(current=True).first()
+    #fair = Fair.objects.filter(current=True).first()
+    year = timezone.now().year
+    fair = Fair.objects.filter(year=year).first()
     exhibitor = Exhibitor.objects.filter(fair=fair, company=company).first()
 
     if request.user.has_perm('companies.base') or (


### PR DESCRIPTION
Fetch the fair from the current timezone year instead of the current set fair. This is because the registration period of the current fair is not opened yet, and we still want to be able to see the orders of every company before the new year shift.