### PR TITLE
feat: Add recruitment_data api endpoint

### DIFF
--- a/api/urls.py
+++ b/api/urls.py
@@ -14,6 +14,7 @@ urlpatterns = [
     url(r"^partners/", views.partners),
     url(r"^questions/?$", views.questions),
     url(r"^recruitment/$", views.recruitment),
+    url(r"^recruitment_data/$", views.recruitment_data),
     url(r"^status/$", views.status),
     url(r"^student_profile$", views.student_profile),
     url(r"^matching/$", views.matching),

--- a/api/util.py
+++ b/api/util.py
@@ -1,0 +1,20 @@
+import csv
+from django.http import HttpResponse
+from collections import OrderedDict
+
+
+def json_to_csv_response(file_name: str, data: list[OrderedDict]):
+    response = HttpResponse(
+        content_type="text/csv",
+    )
+    response["Content-Disposition"] = 'attachment; filename="%s.csv"' % file_name
+    writer = csv.writer(response)
+
+    for i, item in enumerate(data):
+        # Write header
+        if i == 0:
+            writer.writerow(item.keys())
+
+        writer.writerow(item.values())
+
+    return response

--- a/api/views.py
+++ b/api/views.py
@@ -8,6 +8,7 @@ from collections import OrderedDict
 from datetime import datetime
 
 from django.contrib.auth.models import Group
+from django.contrib.auth.decorators import permission_required
 from django.http import JsonResponse, HttpResponseBadRequest, HttpResponse
 from django.shortcuts import get_object_or_404
 from django.utils import timezone
@@ -639,5 +640,59 @@ def recruitment(request):
                 ]
             )
         )
+
+    return JsonResponse(data, safe=False)
+
+@permission_required("recruitment.view_recruitment_applications")
+def recruitment_data(request):
+    fair_year = request.GET.get("fair_year") or None
+    if fair_year:
+        try:
+            fair = Fair.objects.get(year=fair_year)
+        except:
+            return HttpResponse(status=500)
+    else:
+        fair = Fair.objects.get(current=True)
+
+    applications = RecruitmentApplication.objects.filter(
+        recruitment_period__in=RecruitmentPeriod.objects.filter(fair=fair)
+    )
+
+    def with_profile(user, callback):
+        if user.profile:
+            return callback(user.profile)
+        else:
+            return None
+
+    data = [
+        OrderedDict(
+            [
+                ("status", app.status),
+                ("gender", with_profile(app.user, lambda profile: profile.gender)),
+                (
+                    "programme",
+                    with_profile(
+                        app.user,
+                        lambda profile: (profile.programme and profile.programme.name)
+                        or None,
+                    ),
+                ),
+                (
+                    "preferred_language",
+                    with_profile(
+                        app.user,
+                        lambda profile: (
+                            profile.preferred_language
+                            and profile.preferred_language.name
+                        )
+                        or None,
+                    ),
+                ),
+            ]
+        )
+        for app in applications
+    ]
+
+    print(data)
 
     return JsonResponse(data, safe=False)

--- a/api/views.py
+++ b/api/views.py
@@ -650,7 +650,7 @@ def recruitment(request):
 def recruitment_data(request):
     """
     ais.armada.nu/api/recruitment_data?fair_year={FAIR_YEAR}
-    Returns anonymized statistics of recruitment applications.
+    Returns anonymized statistics of recruitment applications as a CSV file.
     If FAIR_YEAR is unset, defaults to the current fair.
     If the fair year does not exist, return 500 error.
     """

--- a/api/views.py
+++ b/api/views.py
@@ -700,6 +700,4 @@ def recruitment_data(request):
         for app in applications
     ]
 
-    print(data)
-
     return JsonResponse(data, safe=False)

--- a/api/views.py
+++ b/api/views.py
@@ -643,6 +643,7 @@ def recruitment(request):
 
     return JsonResponse(data, safe=False)
 
+
 @permission_required("recruitment.view_recruitment_applications")
 def recruitment_data(request):
     """

--- a/api/views.py
+++ b/api/views.py
@@ -20,6 +20,8 @@ from django.utils.crypto import get_random_string
 import api.deserializers as deserializers
 import api.serializers as serializers
 
+from .util import json_to_csv_response
+
 from exhibitors.models import (
     Exhibitor,
     CatalogueIndustry,
@@ -700,4 +702,4 @@ def recruitment_data(request):
         for app in applications
     ]
 
-    return JsonResponse(data, safe=False)
+    return json_to_csv_response("recruitment_data.csv", data)

--- a/api/views.py
+++ b/api/views.py
@@ -645,6 +645,12 @@ def recruitment(request):
 
 @permission_required("recruitment.view_recruitment_applications")
 def recruitment_data(request):
+    """
+    ais.armada.nu/api/recruitment_data?fair_year={FAIR_YEAR}
+    Returns anonymized statistics of recruitment applications.
+    If FAIR_YEAR is unset, defaults to the current fair.
+    If the fair year does not exist, return 500 error.
+    """
     fair_year = request.GET.get("fair_year") or None
     if fair_year:
         try:


### PR DESCRIPTION
## Describe your changes

Fixes: #814 by adding an endpoint `/api/recruitment_data?fair_year={FAIR_YEAR}` (with `fair_year` parameter being optional, defaulting to current fair), giving anonymized statistics about recruitment applications. The endpoint requires the `recruitment.view_recruitment_applications` permission. Exposed fields are: `status, gender, programme, preferred_language`.

### Risk evaluation:

- Does not add any new database migrations, so should be risk-free to push to production. See #816.
- Hides the information behind a permission role, so should not leak any information to unauthorized users. If it were to to that, the information is anonymized.

## Checklist before requesting review

- [x] Feature/fix PRs should add one atomic (as small as possible) feature or fix.
- [x] All code in your PR needs to have been formatted.
- [x] The merge commit title should be prefixed with the type of the PR and a colon and a space, that is "feat", "fix", "doc", "chore", or "refactor", followed by a ": ".
- [x] The merge commit body should reference at least one issue.
- [x] The code compiles and all the tests pass.
