### PR TITLE
doc: Remove format PR checkbox

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -5,7 +5,6 @@ Fixes: #
 ## Checklist before requesting review
 
 - [ ] Feature/fix PRs should add one atomic (as small as possible) feature or fix.
-- [ ] All code in your PR needs to have been formatted.
 - [ ] The merge commit title should be prefixed with the type of the PR and a colon and a space, that is "feat", "fix", "doc", "chore", or "refactor", followed by a ": ".
 - [ ] The merge commit body should reference at least one issue.
 - [ ] The code compiles and all the tests pass.


### PR DESCRIPTION
## Describe your changes

Fixes: #826 by removing the redundant PR checkbox checkbox.

## Checklist before requesting review

- [x] Feature/fix PRs should add one atomic (as small as possible) feature or fix.
- [x] All code in your PR needs to have been formatted.
- [x] The merge commit title should be prefixed with the type of the PR and a colon and a space, that is "feat", "fix", "doc", "chore", or "refactor", followed by a ": ".
- [x] The merge commit body should reference at least one issue.
- [x] The code compiles and all the tests pass.
