### PR TITLE
fix: Remove slow roles variable from call to render home page

### DIFF
--- a/fair/views.py
+++ b/fair/views.py
@@ -57,25 +57,16 @@ def index(request, year=None):
     else:
         events = Event.objects.filter(fair=fair, published=True)
 
+    recruitment_period = RecruitmentPeriod.objects.filter(fair=fair).order_by(
+        "-start_date"
+    )
+
     return render(
         request,
         "fair/home.html",
         {
             "recruitment": {
-                "recruitment_periods": RecruitmentPeriod.objects.filter(
-                    fair=fair
-                ).order_by("-start_date"),
-                "roles": [
-                    {
-                        "parent_role": role,
-                        "child_roles": [
-                            child_role
-                            for child_role in Role.objects.all()
-                            if child_role.has_parent(role)
-                        ],
-                    }
-                    for role in Role.objects.filter(parent_role=None)
-                ],
+                "recruitment_periods": recruitment_period,
             },
             "events": events,
             "fair": fair,


### PR DESCRIPTION
## Describe your changes

Fixes: #821 by removing an unnecessary variable assembling all possible roles in the AIS (there are a lot of roles, so this takes time). This variable does not seem to be used anywhere in the code, but I'm not entirely sure of this, so the fix is a bit risky. Have tested it locally with a copy of the production database, and nothing seems to break.

The relevant file which consumes these variables is here (note that roles are not mentioned anywhere): https://github.com/armada-ths/ais/blob/master/templates/fair/home.html

## Checklist before requesting review

- [x] Feature/fix PRs should add one atomic (as small as possible) feature or fix.
- [x] The merge commit title should be prefixed with the type of the PR and a colon and a space, that is "feat", "fix", "doc", "chore", or "refactor", followed by a ": ".
- [x] The merge commit body should reference at least one issue.
- [x] The code compiles and all the tests pass.
