### PR TITLE
feat: Add organization v2 API

### DIFF
--- a/api/serializers.py
+++ b/api/serializers.py
@@ -25,11 +25,19 @@ def absolute_url(request, path):
     return "{}{}/{}".format(protocol, url, path)
 
 
+def image_url_or_missing_relative(image, missing=MISSING_IMAGE):
+    return image.url if image else missing
+
+
+# This function does not handle trailing slashes
+# A common response is "http://localhost:3000//static/images/no-image.png"
+#
+# Another problem is the usage of ais buckets
+# A common response is "https://ais.armada.nu/https://armada-ais-files.s3.amazonaws.com/profiles/picture_original/3d867d2a75f84e3eb32..."
+#
+# Please use `image_url_or_missing_relative`
 def image_url_or_missing(request, image, missing=MISSING_IMAGE):
-    if image:
-        return absolute_url(request, image.url)
-    else:
-        return absolute_url(request, missing)
+    return absolute_url(request, image.url if image else missing)
 
 
 def obj_name(obj):
@@ -188,6 +196,45 @@ def partner(request, partner):
     )
 
 
+def person_v2(user):
+    # Check that there is a profile for the user
+    try:
+        profile = user.profile
+
+        try:
+            programme = profile.programme.name
+        except AttributeError:
+            programme = None
+
+        return OrderedDict(
+            [
+                ("id", profile.user.pk),
+                ("name", profile.user.get_full_name()),
+                (
+                    "picture",
+                    image_url_or_missing_relative(
+                        profile.picture_original, MISSING_PERSON
+                    ),
+                ),
+                ("linkedin_url", profile.linkedin_url),
+                ("programme", programme),
+                ("role", user.delegated_role.__str__()),
+            ]
+        )
+    except Profile.DoesNotExist:  # There is no profile for this user
+        return OrderedDict(
+            [
+                ("id", user.pk),
+                ("name", user.user.get_full_name()),
+                (
+                    "role",
+                    user.delegated_role.__str__() if user.delegated_role else None,
+                ),
+            ]
+        )
+
+
+# Todo: Deprecate the usage of this serializer (used by armada.nu)
 def person(request, person, role):
     # Check that there are a profile for the user
     try:

--- a/api/urls.py
+++ b/api/urls.py
@@ -10,6 +10,7 @@ urlpatterns = [
     url(r"^fair/", include("fair.api_urls")),
     url(r"^catalogueselections/", views.catalogueselections),
     url(r"^news/", views.news),
+    url(r"^organization/v2", views.organization_v2),
     url(r"^organization/", views.organization),
     url(r"^partners/", views.partners),
     url(r"^questions/?$", views.questions),


### PR DESCRIPTION
## Describe your changes

Fixes: #862 by creating a new API `api/organization/v2` which displays OTs and PGs in their group, with their delegated roles. A new API endpoint had to be created because the structure of the JSON is changed. We will try to deprecate the v1 organization API #864 eventually.

Fixes #863 by removing absolute URLs from the profile images, and instead using relative URLs.

## Checklist before requesting review

- [x] Feature/fix PRs should add one atomic (as small as possible) feature or fix.
- [x] The code compiles and all the tests pass.


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1204488023105642