### PR TITLE
fix: Remove allowed hosts

### DIFF
--- a/ais/production/settings.py
+++ b/ais/production/settings.py
@@ -8,9 +8,6 @@ import os
 from ais.common.settings import *
 
 SECRET_KEY = os.environ.get("SECRET_KEY")
-# This is important so other people can't set their own domains
-# to point to AIS (which would be a security concern).
-ALLOWED_HOSTS = [".armada.nu", "localhost", "armada.nu"]
 
 DEBUG = False
 


### PR DESCRIPTION
## Describe your changes

Fixes: #866 (maybe) by removing allowed hosts which doesn't seem to work anymore with AWS.

According to https://stackoverflow.com/questions/40582423/invalid-http-host-header you usually don't use allowed hosts when hosting in docker.

## Checklist before requesting review

- [x] Feature/fix PRs should add one atomic (as small as possible) feature or fix.
- [x] The code compiles and all the tests pass.
