### PR TITLE
fix: Add EB health check plugin

### DIFF
--- a/ais/common/settings.py
+++ b/ais/common/settings.py
@@ -19,7 +19,6 @@ CRISPY_TEMPLATE_PACK = "bootstrap3"
 
 INSTALLED_APPS = (
     "whitenoise.runserver_nostatic",
-    "magic_link",
     "ebhealthcheck.apps.EBHealthCheckConfig",
     "django.contrib.admin",
     "django.contrib.auth",

--- a/ais/common/settings.py
+++ b/ais/common/settings.py
@@ -19,6 +19,8 @@ CRISPY_TEMPLATE_PACK = "bootstrap3"
 
 INSTALLED_APPS = (
     "whitenoise.runserver_nostatic",
+    "magic_link",
+    "ebhealthcheck.apps.EBHealthCheckConfig",
     "django.contrib.admin",
     "django.contrib.auth",
     "django.contrib.contenttypes",

--- a/ais/production/settings.py
+++ b/ais/production/settings.py
@@ -9,6 +9,8 @@ from ais.common.settings import *
 
 SECRET_KEY = os.environ.get("SECRET_KEY")
 
+ALLOWED_HOSTS = [".armada.nu", "localhost", "armada.nu"]
+
 DEBUG = False
 
 # The URL scheme is slightly different in a production environment

--- a/requirements.txt
+++ b/requirements.txt
@@ -24,5 +24,4 @@ postgis==1.0.4
 django-storages==1.12.3
 boto3==1.21.4
 django-cors-headers
-django-magic-link==0.5.1
 django-ebhealthcheck==2.0.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -24,3 +24,5 @@ postgis==1.0.4
 django-storages==1.12.3
 boto3==1.21.4
 django-cors-headers
+django-magic-link==0.5.1
+django-ebhealthcheck==2.0.2


### PR DESCRIPTION
## Describe your changes

(Maybe) Fixes #866 by adding a EB health check plugin, and reintroducing the allowed hosts for production settings (which are required). Currently the production page crashes because the EB health check in AWS is not part of the allowed hosts, and never will be because the IP is different every time. This plugin somehow works around that.

## Checklist before requesting review

- [x] Feature/fix PRs should add one atomic (as small as possible) feature or fix.
- [x] The code compiles and all the tests pass.
