### PR TITLE
fix: Fix page progression bug that ignored custom getProgression function

### DIFF
--- a/apps/complete_registration/src/screens/form/sidebar/PageCard.tsx
+++ b/apps/complete_registration/src/screens/form/sidebar/PageCard.tsx
@@ -1,7 +1,7 @@
 import React from "react"
 import {
     selectActivePage,
-    selectPageProgress
+    selectFormPageProgress
 } from "../../../store/form/form_selectors"
 import { setPage } from "../../../store/form/form_slice"
 import { AppDispatch, RootState } from "../../../store/store"
@@ -29,7 +29,7 @@ export function Card({ children, className, ...rest }: Props) {
 export function PageCard({ page }: { selected: boolean; page: FormPage }) {
     const dispatch = useDispatch<AppDispatch>()
     const calcProgress = useSelector((state: RootState) =>
-        selectPageProgress(state, page.id)
+        selectFormPageProgress(state, page.id)
     )
     const customProgress = useSelector(page.getProgress ?? (() => null))
     const progress = customProgress != null ? customProgress : calcProgress


### PR DESCRIPTION
The progression selectors used for pages wasn't connected to custom getProgression function before

## Describe your changes

Fixes: #

## Checklist before requesting review

- [ ] Feature/fix PRs should add one atomic (as small as possible) feature or fix.
- [ ] The code compiles and all the tests pass.
