### PR TITLE
chore: Move new FR page to live

### DIFF
--- a/register/urls.py
+++ b/register/urls.py
@@ -27,7 +27,6 @@ app_name = "anmalan"
 urlpatterns = [
     url(r"^$", views.choose_company, name="choose_company"),
     url(r"^(?P<company_pk>[0-9]+)/registration$", views.form, name="registration"),
-    url(r"^new$", views.new_react_cr_view),  # todo: (Didrik 2023) temp
     url(r"^(?P<company_pk>[0-9]+)/events$", views.events, name="events"),
     url(r"^user", views.create_user, name="create_user"),
     url(r"^password/change", views.change_password, name="change_password"),

--- a/register/views.py
+++ b/register/views.py
@@ -165,16 +165,14 @@ def choose_company(request):
     )
 
     if len(company_contacts) == 1:
-        return redirect("anmalan:registration", company_contacts.first().company.pk)
+        # Note: This is the old FR page
+        # return redirect("anmalan:registration", company_contacts.first().company.pk)
+        return new_react_cr_view(request)
 
     # if zero or several company_contacts connections
     return render(
         request, "register/choose_company.html", {"company_contacts": company_contacts}
     )
-
-
-def new_react_cr_view(request):
-    return render(request, "register/inside/registration_complete_new.html")
 
 
 # This function serves the correct template according to the current time of the Armada year and status of the company or user
@@ -384,6 +382,10 @@ def form_initial(request, company, company_contact, fair):
             "contacts": contact_cards,
         },
     )
+
+
+def new_react_cr_view(request):
+    return render(request, "register/inside/registration_complete_new.html")
 
 
 def form_complete(request, company, company_contact, fair, exhibitor):


### PR DESCRIPTION
## Describe your changes

Fixes: #939

This change allows a company to visit the old FR page, by going to the previous URL `<company_id>/registration`. A sales person will need to give the URL to the company if they for some reason would need to access the old page.

## Checklist before requesting review

- [ ] Feature/fix PRs should add one atomic (as small as possible) feature or fix.
- [ ] The code compiles and all the tests pass.
