### PR TITLE
fix: Add export batch as admin model

### DIFF
--- a/accounting/admin.py
+++ b/accounting/admin.py
@@ -41,6 +41,11 @@ class StockAdmin(ModelAdminImproved):
     list_display = ["name", "amount"]
 
 
+@admin.register(ExportBatch)
+class ExportBatchAdmin(ModelAdminImproved):
+    list_display = ["timestamp", "user"]
+
+
 @admin.register(Order)
 class OrderAdmin(ModelAdminImproved):
     readonly_fields = ("amount",)


### PR DESCRIPTION
## Describe your changes

`/admin/accounting/order/` was crashing on add, change. This was because of `ExportBatch` not being defined in admin, and could thus not be rendered.