### PR TITLE
fix: Accepted/rejected status and propagate exhibitor

### DIFF
--- a/dashboard/api/registration/ir.py
+++ b/dashboard/api/registration/ir.py
@@ -14,9 +14,9 @@ from dashboard.api.registration.types.util import get_serializer, put_registrati
 from register.models import SignupLog
 
 
-def handle_ir(request, company, fair, contact):
+def handle_ir(request, company, fair, contact, exhibitor):
     try:
-        registration = get_registration(company, fair, contact, None)
+        registration = get_registration(company, fair, contact, exhibitor)
     except JSONError as error:
         return error.status
 

--- a/dashboard/api/registration/registration.py
+++ b/dashboard/api/registration/registration.py
@@ -17,14 +17,14 @@ def render_company(request, company, contact, exhibitor):
     fair = get_fair()
     period = fair.get_period()
 
-    if period == RegistrationState.BEFORE_IR:
-        return handle_ir(request, company, fair, contact)
-    elif period == RegistrationState.IR:
-        return handle_ir(request, company, fair, contact)
-    elif period == RegistrationState.AFTER_IR:
-        return handle_ir(request, company, fair, contact)
-    elif period == RegistrationState.AFTER_IR_ACCEPTANCE:
-        return handle_ir(request, company, fair, contact)
+    ir_states = [
+        RegistrationState.BEFORE_IR,
+        RegistrationState.IR,
+        RegistrationState.AFTER_IR,
+        RegistrationState.AFTER_IR_ACCEPTANCE,
+    ]
+    if period in ir_states:
+        return handle_ir(request, company, fair, contact, exhibitor)
     elif period == RegistrationState.CR:
         return handle_cr(request, company, fair, contact, exhibitor)
     elif period == RegistrationState.AFTER_CR:
@@ -101,6 +101,7 @@ def get_company(request, company_pk):
         return status.COMPANY_DOES_NOT_EXIST
 
     exhibitor = Exhibitor.objects.filter(fair=get_fair(), company=company).first()
+    print("OUTER exhibitor", exhibitor)
     user = get_user(request)
     permission = UserPermission(user)
     user_is_contact_person = exhibitor and user in exhibitor.contact_persons.all()

--- a/dashboard/api/registration/registration.py
+++ b/dashboard/api/registration/registration.py
@@ -101,7 +101,6 @@ def get_company(request, company_pk):
         return status.COMPANY_DOES_NOT_EXIST
 
     exhibitor = Exhibitor.objects.filter(fair=get_fair(), company=company).first()
-    print("OUTER exhibitor", exhibitor)
     user = get_user(request)
     permission = UserPermission(user)
     user_is_contact_person = exhibitor and user in exhibitor.contact_persons.all()

--- a/dashboard/api/registration/types/util.py
+++ b/dashboard/api/registration/types/util.py
@@ -47,6 +47,14 @@ def get_serializer(request, registration, data=empty, context={}):
             Serializer = CRRegistrationSerializer
         else:
             Serializer = CRSignedRegistrationSerializer
+    elif (
+        registration.type == RegistrationType.AfterInitialRegistrationAcceptanceAccepted
+    ):
+        Serializer = CRRegistrationSerializer
+    elif (
+        registration.type == RegistrationType.AfterInitialRegistrationAcceptanceRejected
+    ):
+        Serializer = CRRegistrationSerializer
     elif registration.type == RegistrationType.AfterCompleteRegistration:
         Serializer = CRSignedRegistrationSerializer
     elif registration.type == RegistrationType.AfterCompleteRegistrationSigned:


### PR DESCRIPTION
The accepted and rejected states were not defined, causing the site to crash when in `AFTER_IR`. 

fix: The exhibitor field wasn't propagated through handle_ir