### PR TITLE
fix: Add DB connection pool library

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,7 @@ RUN apk update \
   gdal-dev linux-headers g++ binutils geos-dev \
   tiff-dev jpeg-dev openjpeg-dev zlib-dev freetype-dev lcms2-dev \
   libwebp-dev tcl-dev tk-dev harfbuzz-dev fribidi-dev libimagequant-dev \
-  libxcb-dev libpng-dev
+  libxcb-dev libpng-dev libpq-dev
 RUN pip install --upgrade pip==21.3.1
 COPY ./requirements.txt .
 RUN pip install -r requirements.txt

--- a/ais/common/settings.py
+++ b/ais/common/settings.py
@@ -84,12 +84,18 @@ AUTHENTICATION_BACKENDS = ("django.contrib.auth.backends.ModelBackend",)
 
 DATABASES = {
     "default": {
-        "ENGINE": "django.contrib.gis.db.backends.postgis",
+        "ENGINE": "dj_db_conn_pool.backends.postgresql",
         "NAME": os.environ.get("DB_NAME", "ais_dev"),
         "USER": os.environ.get("DB_USER", "ais_dev"),
         "PASSWORD": os.environ.get("DB_PASSWORD", "ais_dev"),
         "HOST": os.environ.get("DB_HOST", "127.0.0.1"),
         "PORT": os.environ.get("DB_PORT", "5432"),
+        # https://pypi.org/project/django-db-connection-pool/
+        "POOL_OPTIONS": {
+            "POOL_SIZE": 5,
+            "MAX_OVERFLOW": 10,
+            "RECYCLE": -1,
+        },
     }
 }
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -27,5 +27,6 @@ django-cors-headers
 djangorestframework==3.9.3
 drf-writable-nested==0.7.0
 drf-extra-fields==3.7.0
+django-db-connection-pool==1.2.5
 django-magic-link==0.5.1
 django-autocomplete-light


### PR DESCRIPTION
## Describe your changes

During high load hours, we are getting the error `django.db.utils.OperationalError: FATAL: remaining connection slots are reserved for non-replication superuser connections`. This causes the whole site to freeze for all users for a while (except /admin).

The reason is Django not reusing connections to the database.

Possible solution: https://pypi.org/project/django-db-connection-pool/
