### PR TITLE
fix: Add CONN_MAX_AGE to database settings

### DIFF
--- a/ais/common/settings.py
+++ b/ais/common/settings.py
@@ -90,6 +90,7 @@ DATABASES = {
         "PASSWORD": os.environ.get("DB_PASSWORD", "ais_dev"),
         "HOST": os.environ.get("DB_HOST", "127.0.0.1"),
         "PORT": os.environ.get("DB_PORT", "5432"),
+        "CONN_MAX_AGE": 600,
     }
 }
 


### PR DESCRIPTION
## Describe your changes

This should hopefully add persistent connections https://devcenter.heroku.com/articles/python-concurrency-and-database-connections